### PR TITLE
implement backpressure for enumerable/stream requests

### DIFF
--- a/lib/spear/connection.ex
+++ b/lib/spear/connection.ex
@@ -143,21 +143,12 @@ defmodule Spear.Connection do
     params = {current_window, request_ref}
 
     {:ok, state}
-    # |> do_stage(:set_passive_mode, params)
     |> do_stage(:recv_responses, params)
     |> do_stage(:check_window_size, params)
-    # |> do_stage(:set_active_mode, params)
     |> emit_stage_results()
   end
 
   defp do_stage({:error, state, reason}, _stage, _params), do: {:error, state, reason}
-
-  # defp do_stage({:ok, state}, :set_passive_mode, _params) do
-  # case Mint.HTTP.set_mode(state.conn, :passive) do
-  # {:ok, conn} -> {:ok, put_in(state.conn, conn)}
-  # {:error, reason} -> {:error, state, reason}
-  # end
-  # end
 
   defp do_stage({:ok, state}, :recv_responses, {_current_window, _request_ref}) do
     case receive_next_and_stream(state.conn) do
@@ -186,13 +177,6 @@ defmodule Spear.Connection do
       do_stage({:ok, state}, :recv_responses, {new_window, request_ref})
     end
   end
-
-  # defp do_stage({:ok, state}, :set_active_mode, _params) do
-  # case Mint.HTTP.set_mode(state.conn, :active) do
-  # {:ok, conn} -> {:ok, put_in(state.conn, conn)}
-  # {:error, reason} -> {:error, state, reason}
-  # end
-  # end
 
   defp emit_stage_results({:ok, state}), do: {:cont, {:ok, state}}
   defp emit_stage_results({:error, state, reason}), do: {:halt, {:error, state, reason}}

--- a/lib/spear/writing.ex
+++ b/lib/spear/writing.ex
@@ -65,6 +65,9 @@ defmodule Spear.Writing do
     else
       %AppendResp{result: {:wrong_expected_version, expectation_violation}} ->
         {:error, map_expectation_violation(expectation_violation)}
+
+      {:decode, bad_buffer} ->
+        {:error, {:malformed_response, bad_buffer}}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Spear.MixProject do
     [
       app: :spear,
       version: "0.1.0",
-      elixir: "~> 1.6",
+      elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs()


### PR DESCRIPTION
Closes #1 

Spear allows one to write events using Elixir `Stream`s (`t:Enumerable.t/0`s). The final link in the chain which realizes the stream is the serialization of the data over the wire via `Mint.HTTP.stream_request_body/3`.

As detailed in #1, initially I was seeing append requests for infinite streams fail like so:

```elixir
Stream.iterate(0, &(&1 + 1))
|> Stream.map(fn n -> Spear.Event.new("incremented", n) end)
|> Spear.append(conn, "InfiniteCounter", expect: :empty)
# =>
{:error,
 %Mint.HTTPError{
   module: Mint.HTTP2,
   reason: {:exceeds_window_size, :connection, 26}
 }}
```

This is a back-pressure mechanism which is meant to keep clients from writing events to an HTTP/2 server faster than the server can receive them: each stream in an HTTP/2 connection has a window of bytes it is allowed to send. If it exceeds this window, it must wait until the server sends a WINDOW_UPDATE frame allowing more bytes to be sent.

The strategy before this PR of naively appending iodata to the stream in a `Enum.reduce_while/3` overloaded the connection window (stream 0). It's not really so much that we were writing events faster than the EventStore can handle (we were), but that we weren't listening for WINDOW_UPDATE frames at all and thus not respecting the backpressure mechanism.

Since mint is very low-level and doesn't handle this for you (because it's a process-less architecture), you need to write the mint client to conceptually come-up-for-air every once in a while when sending large payloads to wait for the server. That's what this PR does!