### PR TITLE
implement stream append backpressure with Enumerable.reduce/3

### DIFF
--- a/guides/writing_events.md
+++ b/guides/writing_events.md
@@ -5,24 +5,14 @@ information about the event-writing functionality.
 
 ## Enumeration Characteristics
 
-`event_stream` is an `t:Enumerable.t()` which will be lazily computed as
-events are emitted over-the-wire to the EventStore via gRPC. The procedure
-for emitting events roughly follows this pseudo-code
-
-```elixir
-initiate_grpc_request()
-
-event_stream
-|> Stream.map(&encode_to_wire_format/1)
-|> Enum.each(&emit_event/1)
-
-conclude_grpc_request()
-```
+`event_stream` is an `t:Enumerable.t()` which will be lazily written to the
+EventStore as elements of the stream are computed and serialized on to the
+wire.
 
 This means a few things:
 
 First, you can efficiently emit events from a stream over a large source
-such as a large CSV file
+such as a CSV file with many lines:
 
 ```elixir
 File.stream!("large.csv", read_ahead: 100_000)
@@ -31,6 +21,9 @@ File.stream!("large.csv", read_ahead: 100_000)
 |> Spear.append(conn, "ChargesFromCsvs", batch_size: 25)
 # => :ok
 ```
+
+The stream is only fully run after the last bytes have been written to
+the gRPC network request: the stream is never computed entirely in memory.
 
 Second, you may (but are _not_ encouraged to) write events via an infinite
 stream. A trivial counter mechanism could be implemented like so
@@ -47,7 +40,31 @@ Note that while EventStore streams can in theory store infinitely long
 streams, they are not practically able to do so. EventStore limits the size
 of a single write to `1_048_576` cumulative bytes. This budget can be spent
 on one very large event or, as shown above, many tiny events in a single
-call to `append/4`. Attempting to write more than the budget will fail
+call to `Spear.append/4`. Attempting to write more than the budget will fail
 the request with the above signature and no events in the request will be
 written to the EventStore. This value is configurable in the EventStoreDB
 configuration.
+
+## Blocking
+
+While `Spear.append/4` blocks the caller for the duration of the request,
+it does not fully block the connection. The connection will write chunks of
+data over the wire as allowed by HTTP2 window sizes.
+
+HTTP2 includes a back-pressure mechanism for clients sending large amounts
+of data to the server faster than the server can handle. Servers negotiate
+a maximum number of bytes which the client is allowed to send called a window.
+When the window has been exhausted by streaming data to the server, the client
+must wait until the server replenishes the window. During the downtime between
+exhausting a window and waiting for the server to replenish, Spear suspends
+the exhausted request stream and handles incoming messages from the server
+as normal. Since HTTP2 window sizes are relatively small (usually somewhere
+around the range of 10 and 100 KB), Spear takes conceptual breaks somewhat
+often during large requests. This allows Spear to efficiently multiplex large
+writes with large reads and subscriptions.
+
+## Batching
+
+When appending multiple events, Spear will fit as many messages as possible
+into the same HTTP2 DATA frame. This is valid according to the gRPC
+specification and has the potential to improve performance.

--- a/guides/writing_events.md
+++ b/guides/writing_events.md
@@ -1,0 +1,53 @@
+# Writing Events
+
+This guide covers specifics about the `Spear.append/4` function and general
+information about the event-writing functionality.
+
+## Enumeration Characteristics
+
+`event_stream` is an `t:Enumerable.t()` which will be lazily computed as
+events are emitted over-the-wire to the EventStore via gRPC. The procedure
+for emitting events roughly follows this pseudo-code
+
+```elixir
+initiate_grpc_request()
+
+event_stream
+|> Stream.map(&encode_to_wire_format/1)
+|> Enum.each(&emit_event/1)
+
+conclude_grpc_request()
+```
+
+This means a few things:
+
+First, you can efficiently emit events from a stream over a large source
+such as a large CSV file
+
+```elixir
+File.stream!("large.csv", read_ahead: 100_000)
+|> MyCsvParser.parse_stream()
+|> Stream.map(&MyCsvParser.turn_csv_line_into_spear_event/1)
+|> Spear.append(conn, "ChargesFromCsvs", batch_size: 25)
+# => :ok
+```
+
+Second, you may (but are _not_ encouraged to) write events via an infinite
+stream. A trivial counter mechanism could be implemented like so
+
+```elixir
+iex> Stream.iterate(0, &(&1 + 1))
+...> |> Stream.map(fn n -> Spear.Event.new("incremented", n) end)
+...> |> Spear.append(conn, "InfiniteCounter", timeout: :infinity, expect: :empty)
+{:error,
+ {:grpc_failure, [code: 3, message: "Maximum Append Size of 1048576 Exceeded."]}}
+```
+
+Note that while EventStore streams can in theory store infinitely long
+streams, they are not practically able to do so. EventStore limits the size
+of a single write to `1_048_576` cumulative bytes. This budget can be spent
+on one very large event or, as shown above, many tiny events in a single
+call to `append/4`. Attempting to write more than the budget will fail
+the request with the above signature and no events in the request will be
+written to the EventStore. This value is configurable in the EventStoreDB
+configuration.

--- a/guides/writing_events.md
+++ b/guides/writing_events.md
@@ -18,7 +18,7 @@ such as a CSV file with many lines:
 File.stream!("large.csv", read_ahead: 100_000)
 |> MyCsvParser.parse_stream()
 |> Stream.map(&MyCsvParser.turn_csv_line_into_spear_event/1)
-|> Spear.append(conn, "ChargesFromCsvs", batch_size: 25)
+|> Spear.append(conn, "ChargesFromCsvs", timeout: :infinity)
 # => :ok
 ```
 

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -595,7 +595,7 @@ defmodule Spear do
            GenServer.call(conn, {:request, request}, Keyword.fetch!(opts, :timeout)),
          {{"grpc-status", "0"}, _} <- {List.keyfind(headers, "grpc-status", 0), response} do
       Spear.Writing.decode_append_response(
-        response[:data] || <<>>,
+        response.data,
         opts[:raw?]
       )
     else

--- a/lib/spear/connection.ex
+++ b/lib/spear/connection.ex
@@ -54,7 +54,6 @@ defmodule Spear.Connection do
   end
 
   defp request_and_stream_body(state, request, from) do
-    # TODO make request streams and store them in state
     with {:ok, conn, request_ref} <-
            Mint.HTTP.request(state.conn, @post, request.path, request.headers, :stream),
          request = Request.new(request.messages, request_ref, from),

--- a/lib/spear/connection.ex
+++ b/lib/spear/connection.ex
@@ -8,7 +8,7 @@ defmodule Spear.Connection do
   # https://github.com/elixir-mint/mint/blob/796b8db097d69ede7163acba223ab2045c2773a4/pages/Architecture.md
 
   use GenServer
-  alias Spear.Request
+  alias Spear.Connection.Request
   require Mint.HTTP
 
   defstruct [:conn, requests: %{}]
@@ -55,13 +55,14 @@ defmodule Spear.Connection do
   end
 
   defp request_and_stream_body(state, request, from) do
+    # TODO make request streams and store them in state
     with {:ok, conn, request_ref} <-
            Mint.HTTP.request(state.conn, @post, request.path, request.headers, :stream),
+         request = Request.new(request.messages, request_ref, from),
          state = put_in(state.conn, conn),
-         state = put_in(state.requests[request_ref], %{from: from, response: %{}}),
-         {:ok, state} <- stream_body(state, request_ref, request.messages),
-         {:ok, conn} <- Mint.HTTP.stream_request_body(state.conn, request_ref, :eof) do
-      {:ok, put_in(state.conn, conn)}
+         state = put_in(state.requests[request_ref], request),
+         {:ok, state} <- Request.emit_messages(state, request) do
+      {:ok, state}
     else
       {:error, %__MODULE__{} = state, reason} -> {:error, state, reason}
       {:error, conn, reason} -> {:error, put_in(state.conn, conn), reason}
@@ -84,24 +85,26 @@ defmodule Spear.Connection do
 
   @spec handle_responses(%__MODULE__{}, list()) :: %__MODULE__{}
   defp handle_responses(state, responses) do
-    Enum.reduce(responses, state, &process_response/2)
+    responses
+    |> Enum.reduce(state, &process_response/2)
+    |> Request.continue_requests()
   end
 
   defp process_response({:status, request_ref, status}, state) do
-    put_in(state.requests[request_ref].response[:status], status)
+    put_in(state.requests[request_ref].response.status, status)
   end
 
   defp process_response({:headers, request_ref, new_headers}, state) do
     update_in(
-      state.requests[request_ref].response[:headers],
-      fn headers -> (headers || []) ++ new_headers end
+      state.requests[request_ref].response.headers,
+      fn headers -> headers ++ new_headers end
     )
   end
 
   defp process_response({:data, request_ref, new_data}, state) do
     update_in(
-      state.requests[request_ref].response[:data],
-      fn data -> (data || <<>>) <> new_data end
+      state.requests[request_ref].response.data,
+      fn data -> data <> new_data end
     )
   end
 
@@ -114,96 +117,4 @@ defmodule Spear.Connection do
   end
 
   defp process_response(_unknown, state), do: state
-
-  defp stream_body(state, request_ref, messages) do
-    Enum.reduce_while(
-      messages,
-      {:ok, state},
-      &stream_body_message(&1, &2, request_ref)
-    )
-  end
-
-  defp stream_body_message(message, {:ok, state}, request_ref) do
-    {wire_data, byte_size} = Request.to_wire_data(message)
-    smallest_window = get_smallest_window(state.conn, request_ref)
-
-    with false <- byte_size > smallest_window,
-         {:ok, conn} <- Mint.HTTP.stream_request_body(state.conn, request_ref, wire_data) do
-      {:cont, {:ok, put_in(state.conn, conn)}}
-    else
-      _window_too_small? = true ->
-        recv_until_window_size_increase(state, smallest_window, request_ref)
-
-      {:error, conn, reason} ->
-        {:halt, {:error, put_in(state.conn, conn), reason}}
-    end
-  end
-
-  defp recv_until_window_size_increase(state, current_window, request_ref) do
-    params = {current_window, request_ref}
-
-    {:ok, state}
-    |> do_stage(:recv_responses, params)
-    |> do_stage(:check_window_size, params)
-    |> emit_stage_results()
-  end
-
-  defp do_stage({:error, state, reason}, _stage, _params), do: {:error, state, reason}
-
-  defp do_stage({:ok, state}, :recv_responses, {_current_window, _request_ref}) do
-    case receive_next_and_stream(state.conn) do
-      {:ok, conn, responses} ->
-        state =
-          put_in(state.conn, conn)
-          |> handle_responses(responses)
-
-        {:ok, state}
-
-      {:error, conn, reason} ->
-        state = put_in(state.conn, conn)
-
-        {:error, state, reason}
-    end
-  end
-
-  defp do_stage({:ok, state}, :check_window_size, {current_window, request_ref}) do
-    new_window = get_smallest_window(state.conn, request_ref)
-
-    if new_window > current_window do
-      {:ok, state}
-    else
-      # if the window has not gotten bigger, loop back to the prior stage
-      # in the pipeline: block and wait for more messages from the server
-      do_stage({:ok, state}, :recv_responses, {new_window, request_ref})
-    end
-  end
-
-  defp emit_stage_results({:ok, state}), do: {:cont, {:ok, state}}
-  defp emit_stage_results({:error, state, reason}), do: {:halt, {:error, state, reason}}
-
-  defp receive_next_and_stream(conn) do
-    # YARD allow customization of timeout?
-    receive do
-      message when Mint.HTTP.is_connection_message(conn, message) ->
-        Mint.HTTP.stream(conn, message)
-    after
-      1_000 ->
-        {:error, conn, :window_update_timeout}
-    end
-  end
-
-  defp get_smallest_window(conn, request_ref) do
-    min(
-      Mint.HTTP2.get_window_size(conn, :connection),
-      safe_get_request_window_size(conn, request_ref)
-    )
-  end
-
-  defp safe_get_request_window_size(conn, request_ref) do
-    if Map.has_key?(conn.ref_to_stream_id, request_ref) do
-      Mint.HTTP2.get_window_size(conn, {:request, request_ref})
-    else
-      :infinity
-    end
-  end
 end

--- a/lib/spear/connection.ex
+++ b/lib/spear/connection.ex
@@ -9,7 +9,6 @@ defmodule Spear.Connection do
 
   use GenServer
   alias Spear.Connection.Request
-  require Mint.HTTP
 
   defstruct [:conn, requests: %{}]
 

--- a/lib/spear/connection.ex
+++ b/lib/spear/connection.ex
@@ -143,21 +143,12 @@ defmodule Spear.Connection do
     params = {current_window, request_ref}
 
     {:ok, state}
-    # |> do_stage(:set_passive_mode, params)
     |> do_stage(:recv_responses, params)
     |> do_stage(:check_window_size, params)
-    # |> do_stage(:set_active_mode, params)
     |> emit_stage_results()
   end
 
   defp do_stage({:error, state, reason}, _stage, _params), do: {:error, state, reason}
-
-  # defp do_stage({:ok, state}, :set_passive_mode, _params) do
-  # case Mint.HTTP.set_mode(state.conn, :passive) do
-  # {:ok, conn} -> {:ok, put_in(state.conn, conn)}
-  # {:error, reason} -> {:error, state, reason}
-  # end
-  # end
 
   defp do_stage({:ok, state}, :recv_responses, {_current_window, _request_ref}) do
     case receive_next_and_stream(state.conn) do
@@ -186,13 +177,6 @@ defmodule Spear.Connection do
       do_stage({:ok, state}, :recv_responses, {new_window, request_ref})
     end
   end
-
-  # defp do_stage({:ok, state}, :set_active_mode, _params) do
-  # case Mint.HTTP.set_mode(state.conn, :active) do
-  # {:ok, conn} -> {:ok, put_in(state.conn, conn)}
-  # {:error, reason} -> {:error, state, reason}
-  # end
-  # end
 
   defp emit_stage_results({:ok, state}), do: {:cont, {:ok, state}}
   defp emit_stage_results({:error, state, reason}), do: {:halt, {:error, state, reason}}

--- a/lib/spear/connection/request.ex
+++ b/lib/spear/connection/request.ex
@@ -1,0 +1,194 @@
+defmodule Spear.Connection.Request do
+  @moduledoc false
+
+  # a struct representing a stream-able request
+
+  @type t :: %{
+          continuation: Enumerable.continuation(),
+          request_ref: Mint.Types.request_ref(),
+          buffer: binary(),
+          from: GenServer.from(),
+          response: Spear.Connection.Response.t(),
+          status: :streaming | :done
+        }
+
+  defstruct [:continuation, :buffer, :request_ref, :from, :response, :status]
+
+  def new(event_stream, request_ref, from) do
+    reducer = &reduce_with_suspend/2
+    stream = Stream.map(event_stream, &Spear.Request.to_wire_data/1)
+    continuation = &Enumerable.reduce(stream, &1, reducer)
+
+    %__MODULE__{
+      continuation: continuation,
+      buffer: <<>>,
+      request_ref: request_ref,
+      from: from,
+      response: %Spear.Connection.Response{},
+      status: :streaming
+    }
+  end
+
+  defp reduce_with_suspend(
+         {message, message_size},
+         {message_buffer, message_buffer_size, max_size}
+       )
+       when message_size + message_buffer_size > max_size do
+    {:suspend,
+     {[{message, message_size} | message_buffer], message_size + message_buffer_size, max_size}}
+  end
+
+  defp reduce_with_suspend(
+         {message, message_size},
+         {message_buffer, message_buffer_size, max_size}
+       ) do
+    {:cont,
+     {[{message, message_size} | message_buffer], message_size + message_buffer_size, max_size}}
+  end
+
+  @spec emit_messages(%Spear.Connection{}, %__MODULE__{}) ::
+          {:ok, %Spear.Connection{}} | {:error, %Spear.Connection{}, reason :: any()}
+  def emit_messages(state, %__MODULE__{buffer: <<>>, continuation: continuation} = request) do
+    smallest_window = get_smallest_window(state.conn, request.request_ref)
+
+    {:cont, {[], 0, smallest_window}}
+    |> continuation.()
+    |> handle_contination(state, request)
+  end
+
+  def emit_messages(
+        state,
+        %__MODULE__{buffer: buffer, continuation: continuation} = request
+      ) do
+    smallest_window = get_smallest_window(state.conn, request.request_ref)
+
+    case buffer do
+      <<bytes_to_send::binary-size(smallest_window), rest::binary>> ->
+        state
+        |> put_request(%__MODULE__{request | buffer: rest})
+        |> stream_messages(
+          request.request_ref,
+          [{bytes_to_send, smallest_window}]
+        )
+
+      ^buffer ->
+        # buffer is small enough to be sent in one go
+        # so we resume the happy path of cramming as many messages as possible
+        # into frames
+        buffer_size = byte_size(buffer)
+
+        {:cont, {[{buffer, buffer_size}], buffer_size, smallest_window}}
+        |> continuation.()
+        |> handle_contination(state, request)
+    end
+  end
+
+  defp handle_contination(
+         {finished, {message_buffer, _buffer_size, _max_size}},
+         state,
+         request
+       )
+       when finished in [:done, :halted] do
+    request = put_in(request.status, :done)
+
+    stream_messages(
+      put_request(state, request),
+      request.request_ref,
+      [:eof | message_buffer]
+    )
+  end
+
+  defp handle_contination(
+         {:suspended,
+          {[{overload_message, overload_message_size} | messages_that_fit], buffer_size,
+           max_size}, next_continuation},
+         state,
+         request
+       ) do
+    # stream messages    :list.reverse(messages_that_fit)
+    # turn overload_message into a binary, break it down to allowed size
+    # send what any of what the overload_message binary can be sent,
+    # add the rest of overload_message binary to the buffer
+    fittable_size = max_size - (buffer_size - overload_message_size) - 1
+
+    <<fittable_binary::binary-size(fittable_size), overload_binary::binary>> =
+      IO.iodata_to_binary(overload_message)
+
+    request = %__MODULE__{
+      request
+      | buffer: overload_binary,
+        continuation: next_continuation
+    }
+
+    state
+    |> put_request(request)
+    |> stream_messages(
+      request.request_ref,
+      [{fittable_binary, fittable_size} | messages_that_fit]
+    )
+  end
+
+  defp stream_messages(state, request_ref, [:eof | others]) do
+    case stream_messages(state, request_ref, others) do
+      {:ok, state} -> stream_single(state, request_ref, :eof)
+      error -> error
+    end
+  end
+
+  defp stream_messages(state, request_ref, reversed_messages) when is_list(reversed_messages) do
+    body =
+      reversed_messages
+      |> :lists.reverse()
+      |> Enum.map(fn {message, _size} -> message end)
+
+    # write all messages in one shot as iodata
+    stream_single(state, request_ref, body)
+  end
+
+  defp stream_single(state, request_ref, body) do
+    case Mint.HTTP.stream_request_body(state.conn, request_ref, body) do
+      {:ok, conn} ->
+        {:ok, put_in(state.conn, conn)}
+
+      {:error, conn, reason} ->
+        {:error, put_in(state.conn, conn), reason}
+    end
+  end
+
+  defp put_request(state, %{request_ref: request_ref} = request) do
+    put_in(state.requests[request_ref], request)
+  end
+
+  defp get_smallest_window(conn, request_ref) do
+    min(
+      Mint.HTTP2.get_window_size(conn, :connection),
+      safe_get_request_window_size(conn, request_ref)
+    )
+  end
+
+  defp safe_get_request_window_size(conn, request_ref) do
+    if Map.has_key?(conn.ref_to_stream_id, request_ref) do
+      Mint.HTTP2.get_window_size(conn, {:request, request_ref})
+    else
+      :infinity
+    end
+  end
+
+  def continue_requests(state) do
+    state.requests
+    |> Enum.filter(fn {_request_ref, request} -> request.status == :streaming end)
+    |> Enum.reduce(state, fn {request_ref, request}, state ->
+      case emit_messages(state, request) do
+        {:ok, state} ->
+          state
+
+        {:error, state, reason} ->
+          {%{from: from}, state} = pop_in(state.requests[request_ref])
+
+          GenServer.reply(from, {:error, reason})
+
+          state
+      end
+    end)
+  end
+end

--- a/lib/spear/connection/response.ex
+++ b/lib/spear/connection/response.ex
@@ -1,0 +1,7 @@
+defmodule Spear.Connection.Response do
+  @moduledoc false
+
+  # a slim data structure for storing information about an HTTP/2 response
+
+  defstruct [:status, headers: [], data: <<>>]
+end

--- a/lib/spear/reading/stream.ex
+++ b/lib/spear/reading/stream.ex
@@ -24,7 +24,7 @@ defmodule Spear.Reading.Stream do
 
     wrap_buffer_in_decode_stream(
       state,
-      response[:data] || <<>>,
+      response.data,
       &unfold_continuous/1
     )
   end
@@ -38,7 +38,7 @@ defmodule Spear.Reading.Stream do
         stream =
           wrap_buffer_in_decode_stream(
             state,
-            response[:data] || <<>>,
+            response.data,
             &unfold_chunk/1
           )
 
@@ -101,7 +101,7 @@ defmodule Spear.Reading.Stream do
   defp unfold_continuous(%__MODULE__{buffer: <<>>, from: from} = state) do
     response = request!(%__MODULE__{state | max_count: state.max_count + 1})
 
-    case unfold_chunk(response[:data] || <<>>) do
+    case unfold_chunk(response.data) do
       # discard the first message since it is `from`
       {^from, <<_head, _::binary>> = rest} ->
         unfold_continuous(%__MODULE__{state | buffer: rest})

--- a/lib/spear/writing.ex
+++ b/lib/spear/writing.ex
@@ -65,6 +65,9 @@ defmodule Spear.Writing do
     else
       %AppendResp{result: {:wrong_expected_version, expectation_violation}} ->
         {:error, map_expectation_violation(expectation_violation)}
+
+      {:decode, bad_buffer} ->
+        {:error, {:malformed_response, bad_buffer}}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Spear.MixProject do
     [
       app: :spear,
       version: "0.1.0",
-      elixir: "~> 1.6",
+      elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs()

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Spear.MixProject do
     [
       app: :spear,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs()


### PR DESCRIPTION
closes #1 

uses continuations (`t:Enumerable.continuation/0`) to _suspend_ a stream temporarily while our little client here waits for the server to give us more WINDOW_UPDATE frames (the HTTP2 client->server request backpressure mechanism)