### PR TITLE
refactor config to be validated and implement keep-alive

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,8 +1,7 @@
 make_server = fn ->
   params = [
-    connection_string: "esdb://localhost:2113?tls=true",
-    credentials: {"admin", "changeit"},
-    opts: [
+    connection_string: "esdb://admin:changeit@localhost:2113?tls=true",
+    mint_opts: [
       transport_opts: [
         cacertfile: Path.join([__DIR__, "certs", "ca", "ca.crt"])
       ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,14 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!--
+## 0.2.0 - [Unreleased]
 
-## [Unreleased]
+### Changed
 
-### Added
-
-- foo
-- bar
-- baz
-
--->
+- Refactored connection configuration to go through validation
+    - `:opts` option has been renamed to `:mint_opts`
+    - credentials are passed through the `:connection_string` option or
+      as `:username` and `:password` options
 
 ## 0.1.4 - 2021-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
     - credentials are passed through the `:connection_string` option or
       as `:username` and `:password` options
 
+### Added
+
+- Implemented and documented keep-alive
+    - This can be configured through the `keepAliveInterval` and
+      `keepAliveTimeout` query params in `:connection_string` or by the
+      new `:keep_alive_interval` and `:keep_alive_timeout` configuration
+      options
+
 ## 0.1.4 - 2021-04-16
 
 ### Added

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,10 +3,9 @@ import Config
 config :spear, Spear.Test.ClientFixture, connection_string: "esdb://localhost:2113"
 
 config :spear, :config,
-  connection_string: "esdb://localhost:2113?tls=true",
-  opts: [
+  connection_string: "esdb://admin:changeit@localhost:2113?tls=true",
+  mint_opts: [
     transport_opts: [
       cacertfile: Path.join([__DIR__ | ~w(.. certs ca ca.crt)])
     ]
-  ],
-  credentials: {"admin", "changeit"}
+  ]

--- a/lib/spear/connection.ex
+++ b/lib/spear/connection.ex
@@ -32,21 +32,8 @@ defmodule Spear.Connection do
 
   ## Configuration
 
-  * `:name` - the name of the GenServer. See `t:GenServer.name/0` for more
-    information. When not provided, the spawned process is not aliased to a
-    name and is only addressable through its PID.
-  * `:connection_string` - (**required**) the connection string to parse
-    containing all connection information
-  * `:opts` - (default: `#{inspect(@default_opts)}`) a `t:Keyword.t/0`
-    of options to pass directly to `Mint.HTTP.connect/4`. See the
-    `Mint.HTTP.connect/4` documentation for a full reference. This can be used
-    to specify a custom CA certificate when using EventStoreDB in secure mode
-    (the default in 20+) with a custom set of certificates. The default options
-    cannot be overridden: explicitly passed `:protocols` or `:mode` will be
-    ignored.
-  * `:credentials` - (default: `nil`) a pair (2-element) tuple providing a
-    username and password to use for authentication with the EventStoreDB.
-    E.g. the default username+password of `{"admin", "changeit"}`.
+  See the `Spear.Connection.Configuration` module for available configuration
+  of connections.
 
   ## TLS/SSL configuration and credentials
 

--- a/lib/spear/connection.ex
+++ b/lib/spear/connection.ex
@@ -1,6 +1,4 @@
 defmodule Spear.Connection do
-  @default_opts [protocols: [:http2], mode: :active]
-
   @moduledoc """
   A GenServer which brokers a connection to an EventStoreDB
 

--- a/lib/spear/connection/configuration.ex
+++ b/lib/spear/connection/configuration.ex
@@ -33,6 +33,8 @@ defmodule Spear.Connection.Configuration do
     a keep-alive ping when the ping will be considered unacknowledged. Used
     in conjunction with `:keep_alive_interval`. Set to `-1` to disable
     keep-alive checks. Should be any integer value `>= 10_000`.
+
+  See the `Spear.Connection` module docs for more information about keep-alive.
   """
   @moduledoc since: "0.2.0"
 

--- a/lib/spear/connection/configuration.ex
+++ b/lib/spear/connection/configuration.ex
@@ -1,19 +1,38 @@
 defmodule Spear.Connection.Configuration do
+  @default_mint_opts [protocols: [:http2], mode: :active]
   @moduledoc """
   Configuration for `Spear.Connection`s
 
   ## Options
 
-  TODO redo
-
   * `:name` - the name of the GenServer. See `t:GenServer.name/0` for more
     information. When not provided, the spawned process is not aliased to a
     name and is only addressable through its PID.
-  * `:connection_string` - (**required**) the connection string to parse
-    containing all connection information
-  * `:credentials` - (default: `nil`) a pair (2-element) tuple providing a
-    username and password to use for authentication with the EventStoreDB.
-    E.g. the default username+password of `{"admin", "changeit"}`.
+  * `:connection_string` - the connection string to parse
+    containing all connection information. Other options like `:host` or
+    `:port` will be parsed from the connection string. If options parsed from
+    the connection string are passed, they will be treated as overrides to the
+    value found in the connection string. Consult the EventStoreDB
+    documentation for formulating a valid connection string.
+  * `:mint_opts` - (default: `#{inspect(@default_mint_opts)}`) a keyword
+    list of options to pass to mint. The default values cannot be overridden.
+    This can be useful for configuring TLS. See the
+    [security guide](guides/security.md) for more information.
+  * `:host` - (default: `"localhost"`) the host address of the EventStoreDB
+  * `:port` - (default: `2113`) the external gRPC port of the EventStoreDB
+  * `:tls?` - (default: `false`) whether or not to use TLS to secure the
+    connection to the EventStoreDB
+  * `:username` - (default: `"admin"`) the user to connect as
+  * `:password` - (default: `"changeit"`) the user's password
+  * `:keep_alive_interval` - (default: `10_000`ms - 10s) the period to send
+    keep-alive pings to the EventStoreDB. Set `-1` to disable keep-alive
+    checks. Should be any integer value `>= 10_000`. This option can be used
+    in conjunction with `:keep_alive_timeout` to properly disconnect if the
+    EventStoreDB is not responding to network traffic.
+  * `:keep_alive_timeout` - (default: `10_000`ms - 10s) the time after sending
+    a keep-alive ping when the ping will be considered unacknowledged. Used
+    in conjunction with `:keep_alive_interval`. Set to `-1` to disable
+    keep-alive checks. Should be any integer value `>= 10_000`.
   """
   @moduledoc since: "0.2.0"
 
@@ -21,7 +40,6 @@ defmodule Spear.Connection.Configuration do
 
   # ms
   @default_keepalive 10_000
-  @default_mint_opts [protocols: [:http2], mode: :active]
 
   @typedoc """
   Configuration for a `Spear.Connection`.

--- a/lib/spear/connection/configuration.ex
+++ b/lib/spear/connection/configuration.ex
@@ -1,0 +1,154 @@
+defmodule Spear.Connection.Configuration do
+  @moduledoc """
+  Configuration for `Spear.Connection`s
+
+  ## Options
+
+  TODO
+  """
+  @moduledoc since: "0.2.0"
+
+  require Logger
+
+  # ms
+  @default_keepalive 10_000
+
+  @typedoc """
+  Configuration for a `Spear.Connection`.
+  """
+  @typedoc since: "0.2.0"
+  @type t :: %__MODULE__{
+          scheme: :http | :https,
+          host: Mint.Types.address(),
+          port: :inet.port_number(),
+          tls?: boolean(),
+          username: String.t() | nil,
+          password: String.t() | nil,
+          keep_alive_interval: pos_integer() | false,
+          keep_alive_timeout: pos_integer() | false,
+          mint_opts: Keyword.t(),
+          valid?: boolean(),
+          errors: Keyword.t()
+        }
+
+  defstruct scheme: :http,
+            host: "localhost",
+            port: 2113,
+            tls?: false,
+            username: "admin",
+            password: "changeit",
+            keep_alive_interval: 10_000,
+            keep_alive_timeout: 10_000,
+            mint_opts: [],
+            valid?: true,
+            errors: []
+
+  @doc """
+  Parses configuration from a keyword list
+  """
+  @doc since: "0.2.0"
+  @spec new(Keyword.t()) :: t()
+  def new(opts) when is_list(opts) do
+    config =
+      opts
+      |> Keyword.get(:connection_string)
+      |> from_connection_string()
+      |> Keyword.merge(opts)
+
+    struct(__MODULE__, config)
+    |> validate()
+  end
+
+  defp from_connection_string(connection_string) when is_binary(connection_string) do
+    uri = parse_uri(connection_string)
+    tls? = tls?(uri)
+    {username, password} = parse_credentials(uri)
+
+    [
+      scheme: if(tls?, do: :https, else: :http),
+      host: uri.host,
+      port: uri.port,
+      tls?: tls?,
+      username: username,
+      password: password,
+      keep_alive_interval: keep_alive_interval(uri),
+      keep_alive_timeout: keep_alive_timeout(uri)
+    ]
+  end
+
+  defp from_connection_string(_), do: []
+
+  defp parse_uri(connection_string) do
+    uri = URI.parse(connection_string)
+
+    %URI{uri | query: URI.decode_query(uri.query || "")}
+  end
+
+  defp tls?(%URI{query: %{"tls" => "true"}}), do: true
+  defp tls?(_), do: false
+
+  defp keep_alive_interval(uri), do: keep_alive_value(uri, "keepAliveInterval")
+  defp keep_alive_timeout(uri), do: keep_alive_value(uri, "keepAliveTimeout")
+
+  defp keep_alive_value(uri, key) do
+    with {:ok, value_str} <- Map.fetch(uri.query, key),
+         {value, ""} <- Integer.parse(value_str),
+         value when value >= @default_keepalive <- value do
+      value
+    else
+      -1 ->
+        false
+
+      value when value in 0..@default_keepalive ->
+        Logger.warn("Specified #{key} of #{value} is less than recommended 10_000ms")
+
+        value
+
+      value when is_integer(value) and value < -1 ->
+        # will get picked up by validation
+        value
+
+      _ ->
+        @default_keepalive
+    end
+  end
+
+  defp parse_credentials(uri) do
+    with userinfo when is_binary(userinfo) <- uri.userinfo,
+         [username, password] <- String.split(userinfo, ":") do
+      {username, password}
+    else
+      _ -> {nil, nil}
+    end
+  end
+
+  defp validate(%__MODULE__{} = config) do
+    errors =
+      config
+      |> Map.from_struct()
+      |> Enum.reduce([], &validate/2)
+
+    %__MODULE__{config | errors: errors, valid?: errors == []}
+  end
+
+  defp validate({:keep_alive_interval = key, value}, errors)
+       when is_integer(value) and value <= 0 do
+    [{key, "keepAliveInterval must be greater than 1"} | errors]
+  end
+
+  defp validate({:keep_alive_timeout = key, value}, errors)
+       when is_integer(value) and value <= 0 do
+    [{key, "keepAliveTimeout must be greater than 1"} | errors]
+  end
+
+  defp validate({:port = key, value}, errors)
+       when not is_integer(value) or value not in 1..65_535 do
+    [{key, "#{inspect(value)} is not a valid port number"} | errors]
+  end
+
+  defp validate({:scheme = key, value}, errors) when value not in [:http, :https] do
+    [{key, "scheme #{inspect(value)} must be :http or :https"} | errors]
+  end
+
+  defp validate({_k, _v}, errors), do: errors
+end

--- a/lib/spear/connection/configuration.ex
+++ b/lib/spear/connection/configuration.ex
@@ -12,6 +12,7 @@ defmodule Spear.Connection.Configuration do
 
   # ms
   @default_keepalive 10_000
+  @default_mint_opts [protocols: [:http2], mode: :active]
 
   @typedoc """
   Configuration for a `Spear.Connection`.
@@ -45,6 +46,8 @@ defmodule Spear.Connection.Configuration do
 
   @doc """
   Parses configuration from a keyword list
+
+  This function is used internally by `Spear.Connection` when connecting.
   """
   @doc since: "0.2.0"
   @spec new(Keyword.t()) :: t()
@@ -54,6 +57,7 @@ defmodule Spear.Connection.Configuration do
       |> Keyword.get(:connection_string)
       |> from_connection_string()
       |> Keyword.merge(opts)
+      |> override_mint_opts()
 
     struct(__MODULE__, config)
     |> validate()
@@ -120,6 +124,15 @@ defmodule Spear.Connection.Configuration do
     else
       _ -> {nil, nil}
     end
+  end
+
+  defp override_mint_opts(opts) do
+    mint_opts =
+      opts
+      |> Keyword.get(:mint_opts, [])
+      |> Keyword.merge(@default_mint_opts)
+
+    Keyword.merge(opts, mint_opts: mint_opts)
   end
 
   defp validate(%__MODULE__{} = config) do

--- a/lib/spear/connection/configuration.ex
+++ b/lib/spear/connection/configuration.ex
@@ -11,13 +11,6 @@ defmodule Spear.Connection.Configuration do
     name and is only addressable through its PID.
   * `:connection_string` - (**required**) the connection string to parse
     containing all connection information
-  * `:opts` - (default: `#{inspect(@default_opts)}`) a `t:Keyword.t/0`
-    of options to pass directly to `Mint.HTTP.connect/4`. See the
-    `Mint.HTTP.connect/4` documentation for a full reference. This can be used
-    to specify a custom CA certificate when using EventStoreDB in secure mode
-    (the default in 20+) with a custom set of certificates. The default options
-    cannot be overridden: explicitly passed `:protocols` or `:mode` will be
-    ignored.
   * `:credentials` - (default: `nil`) a pair (2-element) tuple providing a
     username and password to use for authentication with the EventStoreDB.
     E.g. the default username+password of `{"admin", "changeit"}`.
@@ -59,6 +52,11 @@ defmodule Spear.Connection.Configuration do
             mint_opts: [],
             valid?: true,
             errors: []
+
+  @doc false
+  def credentials(%__MODULE__{username: username, password: password}) do
+    {username, password}
+  end
 
   @doc """
   Parses configuration from a keyword list

--- a/lib/spear/connection/configuration.ex
+++ b/lib/spear/connection/configuration.ex
@@ -4,7 +4,23 @@ defmodule Spear.Connection.Configuration do
 
   ## Options
 
-  TODO
+  TODO redo
+
+  * `:name` - the name of the GenServer. See `t:GenServer.name/0` for more
+    information. When not provided, the spawned process is not aliased to a
+    name and is only addressable through its PID.
+  * `:connection_string` - (**required**) the connection string to parse
+    containing all connection information
+  * `:opts` - (default: `#{inspect(@default_opts)}`) a `t:Keyword.t/0`
+    of options to pass directly to `Mint.HTTP.connect/4`. See the
+    `Mint.HTTP.connect/4` documentation for a full reference. This can be used
+    to specify a custom CA certificate when using EventStoreDB in secure mode
+    (the default in 20+) with a custom set of certificates. The default options
+    cannot be overridden: explicitly passed `:protocols` or `:mode` will be
+    ignored.
+  * `:credentials` - (default: `nil`) a pair (2-element) tuple providing a
+    username and password to use for authentication with the EventStoreDB.
+    E.g. the default username+password of `{"admin", "changeit"}`.
   """
   @moduledoc since: "0.2.0"
 

--- a/lib/spear/connection/keep_alive_timer.ex
+++ b/lib/spear/connection/keep_alive_timer.ex
@@ -1,0 +1,66 @@
+defmodule Spear.Connection.KeepAliveTimer do
+  @moduledoc false
+
+  # a struct & functions for curating the keep-alive timer
+
+  # gRPC keep-alive is just HTTP2 keep-alive: send PING frames every interval
+  # after receiving some data and wait at most timeout before saying the
+  # connection is severed
+
+  # note that `:interval_timer` is not an actual interval timer as with
+  # `:timer.send_interval/3`. See #10 for info on keep-alive conformity
+
+  alias Spear.Connection.Configuration, as: Config
+
+  defstruct interval_timer: nil, interval: 10_000, timeout: 10_000, timeout_timers: %{}
+
+  def start(%Config{keep_alive_interval: interval, keep_alive_timeout: timeout})
+      when interval == false or timeout == false,
+      do: %__MODULE__{}
+
+  def start(%Config{keep_alive_interval: interval, keep_alive_timeout: timeout}) do
+    %__MODULE__{
+      interval_timer: start_interval_timer(interval),
+      interval: interval,
+      timeout: timeout
+    }
+  end
+
+  def reset_interval_timer(%__MODULE__{} = keep_alive_timer) do
+    :timer.cancel(keep_alive_timer.interval_timer)
+
+    %__MODULE__{
+      keep_alive_timer
+      | interval_timer: start_interval_timer(keep_alive_timer.interval)
+    }
+  end
+
+  def clear(%__MODULE__{interval_timer: interval_timer, timeout_timers: timeout_timers}) do
+    # note that :timer.cancel/1 does not raise when the interval_timer is nil
+    :timer.cancel(interval_timer)
+
+    :ok = Enum.each(timeout_timers, fn {_request_ref, timer} -> :timer.cancel(timer) end)
+
+    %__MODULE__{}
+  end
+
+  def start_timeout_timer(%__MODULE__{} = keep_alive_timer, request_ref) do
+    {:ok, timeout_timer} = :timer.send_after(keep_alive_timer.timeout, :keep_alive_expired)
+
+    put_in(keep_alive_timer.timeout_timers[request_ref], timeout_timer)
+  end
+
+  def clear_after_timer(%__MODULE__{} = keep_alive_timer, request_ref) do
+    {timeout_timer, keep_alive_timer} = pop_in(keep_alive_timer.timeout_timers[request_ref])
+
+    :timer.cancel(timeout_timer)
+
+    keep_alive_timer
+  end
+
+  defp start_interval_timer(interval) do
+    {:ok, interval_timer} = :timer.send_after(interval, :keep_alive)
+
+    interval_timer
+  end
+end

--- a/lib/spear/connection/request.ex
+++ b/lib/spear/connection/request.ex
@@ -200,7 +200,10 @@ defmodule Spear.Connection.Request do
 
   def continue_requests(state) do
     state.requests
-    |> Enum.filter(fn {_request_ref, request} -> request.status == :streaming end)
+    |> Enum.filter(fn
+      {_request_ref, %__MODULE__{} = request} -> request.status == :streaming
+      _ -> false
+    end)
     |> Enum.reduce(state, fn {request_ref, request}, state ->
       case emit_messages(state, request) do
         {:ok, state} ->

--- a/lib/spear/request.ex
+++ b/lib/spear/request.ex
@@ -36,7 +36,7 @@ defmodule Spear.Request do
   defp headers(credentials \\ nil) do
     maybe_auth_header =
       case credentials do
-        {username, password} ->
+        {username, password} when is_binary(username) and is_binary(password) ->
           [{"authorization", "Basic " <> Base.encode64("#{username}:#{password}")}]
 
         _ ->

--- a/test/spear/connection/configuration_test.exs
+++ b/test/spear/connection/configuration_test.exs
@@ -102,4 +102,20 @@ defmodule Spear.Connection.ConfigurationTest do
 
     assert config.valid? == true
   end
+
+  test "mint protocols and mode options cannot be overriden" do
+    config =
+      Config.new(
+        scheme: :http,
+        username: "admin",
+        password: "changeit",
+        host: "localhost",
+        port: 2113,
+        mint_opts: [protocols: [:http2, :http], mode: :passive]
+      )
+
+    assert config.valid? == true
+    assert config.mint_opts[:protocols] == [:http2]
+    assert config.mint_opts[:mode] == :active
+  end
 end

--- a/test/spear/connection/configuration_test.exs
+++ b/test/spear/connection/configuration_test.exs
@@ -1,0 +1,105 @@
+defmodule Spear.Connection.ConfigurationTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Spear.Connection.Configuration, as: Config
+
+  test "a minimal connection string produces valid config" do
+    config = Config.new(connection_string: "esdb://localhost:2113")
+    assert config.valid? == true
+    assert config.tls? == false
+    assert config.scheme == :http
+
+    assert config.keep_alive_interval == 10_000
+    assert config.keep_alive_timeout == 10_000
+  end
+
+  test "a tls connection string passes validation" do
+    config =
+      Config.new(
+        connection_string:
+          "esdb://admin:changeit@localhost:2113?tls=true&keepAliveInterval=30000&keepAliveTimeout=15000"
+      )
+
+    assert config.valid? == true
+    assert config.tls? == true
+    assert config.scheme == :https
+    assert config.username == "admin"
+    assert config.password == "changeit"
+  end
+
+  test "keep-alive interval/timeout can be disabled with -1" do
+    config =
+      Config.new(
+        connection_string:
+          "esdb://localhost:2113?tls=true&keepAliveInterval=-1&keepAliveTimeout=-1"
+      )
+
+    assert config.valid? == true
+    assert config.keep_alive_interval == false
+    assert config.keep_alive_interval == false
+  end
+
+  test "small keep-alive times emit warning log messages" do
+    log =
+      capture_log([level: :warn], fn ->
+        config =
+          Config.new(
+            connection_string:
+              "esdb://localhost:2113?tls=true&keepAliveInterval=1000&keepAliveTimeout=1000"
+          )
+
+        assert config.valid? == true
+        assert config.keep_alive_interval == 1_000
+        assert config.keep_alive_timeout == 1_000
+      end)
+
+    assert log =~ "keepAliveInterval"
+    assert log =~ "keepAliveTimeout"
+    assert log =~ "less than recommended 10_000ms"
+  end
+
+  test "negative keep-alive values emit errors" do
+    config =
+      Config.new(
+        connection_string:
+          "esdb://localhost:2113?tls=true&keepAliveInterval=-500&keepAliveTimeout=-500"
+      )
+
+    assert config.valid? == false
+    assert [_ | _] = config.errors
+
+    for {key, error_msg} <- config.errors do
+      assert key in ~w[keep_alive_interval keep_alive_timeout]a
+      assert error_msg =~ "must be greater than 1"
+    end
+  end
+
+  test "port number 0 gets rejected by validation" do
+    config = Config.new(connection_string: "esdb://localhost:0")
+    assert config.valid? == false
+    assert [{:port, error_msg}] = config.errors
+    assert error_msg =~ "0 is not a valid port number"
+  end
+
+  test "attempting to override scheme with an invalid value fails validation" do
+    config = Config.new(connection_string: "esdb://localhost:2113", scheme: :esdb)
+    assert config.valid? == false
+    assert [{:scheme, error_msg}] = config.errors
+    assert error_msg =~ "scheme :esdb must be :http or :https"
+  end
+
+  test "connection params can be entirely crafted without the connection string" do
+    config =
+      Config.new(
+        scheme: :http,
+        username: "admin",
+        password: "changeit",
+        host: "localhost",
+        port: 2113
+      )
+
+    assert config.valid? == true
+  end
+end

--- a/test/spear/connection/keep_alive_timer_test.exs
+++ b/test/spear/connection/keep_alive_timer_test.exs
@@ -1,0 +1,41 @@
+defmodule Spear.Connection.KeepAliveTimerTest do
+  use ExUnit.Case, async: true
+
+  alias Spear.Connection.Configuration, as: Config
+  alias Spear.Connection.KeepAliveTimer
+
+  test "a connection configured to disable keep-alive sets no timers" do
+    timer =
+      [connection_string: "esdb://localhost:2113?keepAliveInterval=-1"]
+      |> Config.new()
+      |> KeepAliveTimer.start()
+
+    assert timer.interval_timer == nil
+    assert timer.timeout_timers == %{}
+  end
+
+  test "starting a timeout timer inserts the timer into timout_timers" do
+    ref = make_ref()
+
+    timer = %KeepAliveTimer{interval: 20, timeout: 10} |> KeepAliveTimer.start_timeout_timer(ref)
+
+    assert_receive :keep_alive_expired
+
+    assert Map.has_key?(timer.timeout_timers, ref)
+  end
+
+  test "canceling a timeout timer takes the timer out of timout_timers" do
+    ref = make_ref()
+
+    timer =
+      %KeepAliveTimer{interval: 300, timeout: 200} |> KeepAliveTimer.start_timeout_timer(ref)
+
+    assert Map.has_key?(timer.timeout_timers, ref)
+
+    timer = KeepAliveTimer.clear_after_timer(timer, ref)
+
+    refute Map.has_key?(timer.timeout_timers, ref)
+
+    refute_receive :keep_alive_expired
+  end
+end

--- a/test/spear/connection_test.exs
+++ b/test/spear/connection_test.exs
@@ -22,7 +22,7 @@ defmodule Spear.ConnectionTest do
 
   describe "given invalid params" do
     setup do
-      [params: []]
+      [params: [port: -1]]
     end
 
     test "the connection does an :ignore start-up and logs an error", c do
@@ -32,7 +32,8 @@ defmodule Spear.ConnectionTest do
         end)
 
       assert log =~ "Spear.Connection"
-      assert log =~ "did not find enough information"
+      assert log =~ "Invalid configuration passed"
+      assert log =~ "port: -1 is not a valid port number"
     end
   end
 

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -166,6 +166,12 @@ defmodule SpearTest do
       assert GenServer.call(c.conn, :close) == {:ok, :closed}
       assert_receive {:eos, :closed}
     end
+
+    test "a keep-alive timeout disconnects the conn and the conn reconnects", c do
+      send(c.conn, :keep_alive_expired)
+      assert_receive {:eos, :closed}
+      assert Spear.ping(c.conn) == :pong
+    end
   end
 
   describe "given no prior state" do
@@ -431,6 +437,12 @@ defmodule SpearTest do
       # reset ACL
       metadata = %Spear.StreamMetadata{acl: Spear.Acl.allow_all()}
       assert Spear.set_stream_metadata(c.conn, c.stream_name, metadata) == :ok
+    end
+
+    test "a server may be told it needs to do a keep-alive ping check", c do
+      # this is mostly for coverage :(
+      send(c.conn, :keep_alive)
+      assert Spear.ping(c.conn) == :pong
     end
   end
 


### PR DESCRIPTION
connects #10 

preparing to implement keep-alive and need to get the configuration for it squared away

this should be a better config implementation in the long-run anyways. It's a kind of ecto-style validation without having to depend on ecto