### PR TITLE
implement users API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 - [Unreleased]
+
+### Added
+
+- Added record interface modules for all remaining APIs
+
 ## 0.2.1 - 2021-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Added
 
 - Added record interface modules for all remaining APIs
+- Added functions for interacting with the Users API
+    - `Spear.change_user_password/5`
+    - `Spear.create_user/6`
+    - `Spear.delete_user/3`
+    - `Spear.disable_user/3`
+    - `Spear.enable_user/3`
+    - `Spear.reset_user_password/4`
+    - `Spear.update_user/6`
+    - `Spear.user_details/3`
+    - associated functions in `Spear.Client`
 
 ## 0.2.1 - 2021-04-17
 

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -665,7 +665,7 @@ defmodule Spear do
   end
 
   @doc """
-  Pings the connection
+  Pings a connection
 
   This can be used to ensure that the connection process is alive, or to
   roughly measure the latency between the connection process and EventStoreDB.
@@ -838,7 +838,28 @@ defmodule Spear do
     |> append(conn, meta_stream(stream), opts)
   end
 
+  @doc """
+  Creates an EventStoreDB user
+
+  ## Options
+
+  All options are passed to `Spear.request/5`.
+
+  ## Examples
+
+      iex> Spear.create_user(conn, "Aladdin", "aladdin", "open sesame", ["$ops"], credentials: {"admin", "changeit"})
+      :ok
+  """
+  @doc since: "0.3.0"
   @doc api: :users
+  @spec create_user(
+          Spear.Connection.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          [String.t()],
+          Keyword.t()
+        ) :: :ok | {:error, any()}
   def create_user(conn, full_name, login_name, password, groups, opts \\ []) do
     import Spear.Records.Users
 
@@ -859,7 +880,30 @@ defmodule Spear do
     end
   end
 
+  @doc """
+  Updates an existing EventStoreDB user
+
+  ## Options
+
+  All options are passed to `Spear.request/5`.
+
+  ## Examples
+
+      iex> Spear.create_user(conn, "Aladdin", "aladdin", "open sesame", ["$ops"], credentials: {"admin", "changeit"})
+      :ok
+      iex> Spear.update_user(conn, "Aladdin", "aladdin", "open sesame", ["$admins"], credentials: {"admin", "changeit"})
+      :ok
+  """
+  @doc since: "0.3.0"
   @doc api: :users
+  @spec update_user(
+          Spear.Connection.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          [String.t()],
+          Keyword.t()
+        ) :: :ok | {:error, any()}
   def update_user(conn, full_name, login_name, password, groups, opts \\ []) do
     import Spear.Records.Users
 
@@ -880,7 +924,26 @@ defmodule Spear do
     end
   end
 
+  @doc """
+  Deletes a user from the EventStoreDB
+
+  EventStoreDB users are deleted by the `login_name` parameter as passed
+  to `Spear.create_user/6`.
+
+  ## Options
+
+  All options are passed to `Spear.request/5`.
+
+  ## Examples
+
+      iex> Spear.create_user(conn, "Aladdin", "aladdin", "open sesame", ["$ops"], credentials: {"admin", "changeit"})
+      :ok
+      iex> Spear.delete_user(conn, "aladdin", credentials: {"admin", "changeit"})
+      :ok
+  """
+  @doc since: "0.3.0"
   @doc api: :users
+  @spec delete_user(Spear.Connection.t(), String.t(), Keyword.t()) :: :ok | {:error, any()}
   def delete_user(conn, login_name, opts \\ []) do
     import Spear.Records.Users
 
@@ -892,7 +955,27 @@ defmodule Spear do
     end
   end
 
+  @doc """
+  Enables a user to make requests against the EventStoreDB
+
+  Disabling and enabling users are an alternative to repeatedly creating and
+  deleting users and is suitable for when a user needs to be temporarily
+  denied access.
+
+  ## Options
+
+  All options are passed to `Spear.request/5`.
+
+  ## Examples
+
+      iex> Spear.disable_user(conn, "aladdin")
+      :ok
+      iex> Spear.enable_user(conn, "aladdin")
+      :ok
+  """
+  @doc since: "0.3.0"
   @doc api: :users
+  @spec enable_user(Spear.Connection.t(), String.t(), Keyword.t()) :: :ok | {:error, any()}
   def enable_user(conn, login_name, opts \\ []) do
     import Spear.Records.Users
 
@@ -904,7 +987,28 @@ defmodule Spear do
     end
   end
 
+  @doc """
+  Disables a user's ability to make requests against the EventStoreDB
+
+  This can be used in conjunction with `Spear.enable_user/3` to temporarily
+  deny access to a user as an alternative to deleting and creating the user.
+  Enabling and disabling users does not require the password of the user:
+  just that requestor to be in the `$admins` group.
+
+  ## Options
+
+  All options are passed to `Spear.request/5`.
+
+  ## Examples
+
+      iex> Spear.enable_user(conn, "aladdin")
+      :ok
+      iex> Spear.disable_user(conn, "aladdin")
+      :ok
+  """
+  @doc since: "0.3.0"
   @doc api: :users
+  @spec disable_user(Spear.Connection.t(), String.t(), Keyword.t()) :: :ok | {:error, any()}
   def disable_user(conn, login_name, opts \\ []) do
     import Spear.Records.Users
 
@@ -916,7 +1020,30 @@ defmodule Spear do
     end
   end
 
+  @doc """
+  Fetches details about an EventStoreDB user
+
+  ## Options
+
+  All options are passed to `Spear.request/5`.
+
+  ## Examples
+
+      iex> Spear.create_user(conn, "Aladdin", "aladdin", "open sesame", ["$ops"])
+      :ok
+      iex> Spear.user_details(conn, "aladdin")
+      {:ok,
+       %Spear.User{
+         enabled?: true,
+         full_name: "Aladdin",
+         groups: ["$ops"],
+         last_updated: ~U[2021-04-18 16:48:38.583313Z],
+         login_name: "aladdin"
+       }}
+  """
+  @doc since: "0.3.0"
   @doc api: :users
+  @spec user_details(Spear.Connection.t(), String.t(), Keyword.t()) :: :ok | {:error, any()}
   def user_details(conn, login_name, opts \\ []) do
     import Spear.Records.Users
 
@@ -928,6 +1055,23 @@ defmodule Spear do
     end
   end
 
+  @doc """
+  Changes a user's password by providing the current password
+
+  This can be accomplished regardless of the current credentials since the
+  user's current password is provided.
+
+  ## Options
+
+  All options are passed to `Spear.request/5`.
+
+  ## Examples
+
+      iex> Spear.create_user(conn, "Aladdin", "aladdin", "changeit", ["$ops"])
+      :ok
+      iex> Spear.change_user_password(conn, "aladdin", "changeit", "open sesame")
+      :ok
+  """
   @doc api: :users
   def change_user_password(conn, login_name, current_password, new_password, opts \\ []) do
     import Spear.Records.Users
@@ -948,7 +1092,28 @@ defmodule Spear do
     end
   end
 
+  @doc """
+  Resets a user's password
+
+  This can be only requested by a user in the `$admins` group. The current
+  password is not passed in this request, so this function is suitable for
+  setting a new password when the current password is lost.
+
+  ## Options
+
+  All options are passed to `Spear.request/5`.
+
+  ## Examples
+
+      iex> Spear.create_user(conn, "Aladdin", "aladdin", "changeit", ["$ops"])
+      :ok
+      iex> Spear.reset_user_password(conn, "aladdin", "open sesame", credentials: {"admin", "changeit"})
+      :ok
+  """
+  @doc since: "0.3.0"
   @doc api: :users
+  @spec reset_user_password(Spear.Connection.t(), String.t(), String.t(), Keyword.t()) ::
+          :ok | {:error, any()}
   def reset_user_password(conn, login_name, new_password, opts \\ []) do
     import Spear.Records.Users
 
@@ -1027,6 +1192,11 @@ defmodule Spear do
 
   @doc """
   Parses an EventStoreDB timestamp into a `DateTime.t()` in UTC time.
+
+  ## Examples
+
+      iex> Spear.parse_stamp(16187636458580612)
+      {:ok, ~U[2021-04-18 16:34:05.858061Z]}
   """
   @doc since: "0.3.0"
   @doc api: :utils

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -63,8 +63,6 @@ defmodule Spear do
   contents extracted from the protobuf messages (indirectly via `:gpb`).
   """
 
-  import Spear.Records.Streams, only: [append_resp: 1]
-
   @doc """
   Collects an EventStoreDB stream into an enumerable
 
@@ -159,6 +157,7 @@ defmodule Spear do
       5
   """
   @doc since: "0.1.0"
+  @doc api: :streams
   @spec stream!(
           connection :: Spear.Connection.t(),
           stream_name :: String.t() | :all,
@@ -294,6 +293,7 @@ defmodule Spear do
       ]
   """
   @doc since: "0.1.0"
+  @doc api: :streams
   @spec read_stream(Spear.Connection.t(), String.t(), Keyword.t()) ::
           {:ok, event_stream :: Enumerable.t()} | {:error, any()}
   def read_stream(connection, stream_name, opts \\ []) do
@@ -381,6 +381,7 @@ defmodule Spear do
       {:error, %Spear.ExpectationViolation{current: 1, expected: :empty}}
   """
   @doc since: "0.1.0"
+  @doc api: :streams
   @spec append(
           event_stream :: Enumerable.t(),
           connection :: Spear.Connection.t(),
@@ -388,6 +389,8 @@ defmodule Spear do
           opts :: Keyword.t()
         ) :: :ok | {:error, reason :: Spear.ExpectationViolation.t() | any()}
   def append(event_stream, conn, stream_name, opts \\ []) when is_binary(stream_name) do
+    import Spear.Records.Streams, only: [append_resp: 1]
+
     # YARD gRPC timeout?
     default_write_opts = [
       expect: :any,
@@ -506,6 +509,7 @@ defmodule Spear do
       {:eos, :closed}
   """
   @doc since: "0.1.0"
+  @doc api: :streams
   @spec subscribe(
           connection :: Spear.Connection.t(),
           subscriber :: pid() | GenServer.name(),
@@ -565,6 +569,7 @@ defmodule Spear do
       :ok
   """
   @doc since: "0.1.0"
+  @doc api: :streams
   @spec cancel_subscription(
           connection :: Spear.Connection.t(),
           subscription_reference :: reference(),
@@ -631,6 +636,7 @@ defmodule Spear do
       []
   """
   @doc since: "0.1.0"
+  @doc api: :streams
   @spec delete_stream(
           connection :: Spear.Connection.t(),
           stream_name :: String.t(),
@@ -676,6 +682,7 @@ defmodule Spear do
       :pong
   """
   @doc since: "0.1.2"
+  @doc api: :utils
   @spec ping(connection :: Spear.Connection.t(), timeout()) :: :pong | {:error, any()}
   def ping(conn, timeout \\ 5_000), do: Connection.call(conn, :ping, timeout)
 
@@ -706,6 +713,7 @@ defmodule Spear do
       :ok
   """
   @doc since: "0.1.3"
+  @doc api: :utils
   @spec set_global_acl(
           connection :: Spear.Connection.t(),
           user_acl :: Spear.Acl.t(),
@@ -736,6 +744,7 @@ defmodule Spear do
       "$$es_supported_clients"
   """
   @doc since: "0.1.3"
+  @doc api: :utils
   @spec meta_stream(stream :: String.t()) :: String.t()
   def meta_stream(stream) when is_binary(stream), do: "$$" <> stream
 
@@ -767,6 +776,7 @@ defmodule Spear do
       {:ok, %Spear.StreamMetadata{max_count: 50_000, ..}}
   """
   @doc since: "0.1.3"
+  @doc api: :streams
   @spec get_stream_metadata(
           connection :: Spear.Connection.t(),
           stream :: String.t(),
@@ -818,6 +828,7 @@ defmodule Spear do
       :ok
   """
   @doc since: "0.1.3"
+  @doc api: :streams
   @spec set_stream_metadata(
           connection :: Spear.Connection.t(),
           stream :: String.t(),
@@ -833,6 +844,7 @@ defmodule Spear do
     |> append(conn, meta_stream(stream), opts)
   end
 
+  @doc api: :users
   def create_user(conn, full_name, login_name, password, groups, opts \\ []) do
     import Spear.Records.Users
 
@@ -853,6 +865,7 @@ defmodule Spear do
     end
   end
 
+  @doc api: :users
   def update_user(conn, full_name, login_name, password, groups, opts \\ []) do
     import Spear.Records.Users
 
@@ -873,6 +886,7 @@ defmodule Spear do
     end
   end
 
+  @doc api: :users
   def delete_user(conn, login_name, opts \\ []) do
     import Spear.Records.Users
 
@@ -884,6 +898,7 @@ defmodule Spear do
     end
   end
 
+  @doc api: :users
   def enable_user(conn, login_name, opts \\ []) do
     import Spear.Records.Users
 
@@ -895,6 +910,7 @@ defmodule Spear do
     end
   end
 
+  @doc api: :users
   def disable_user(conn, login_name, opts \\ []) do
     import Spear.Records.Users
 
@@ -906,6 +922,7 @@ defmodule Spear do
     end
   end
 
+  @doc api: :users
   def user_details(conn, login_name, opts \\ []) do
     import Spear.Records.Users
 
@@ -917,6 +934,7 @@ defmodule Spear do
     end
   end
 
+  @doc api: :users
   def change_user_password(conn, login_name, current_password, new_password, opts \\ []) do
     import Spear.Records.Users
 
@@ -936,6 +954,7 @@ defmodule Spear do
     end
   end
 
+  @doc api: :users
   def reset_user_password(conn, login_name, new_password, opts \\ []) do
     import Spear.Records.Users
 
@@ -985,6 +1004,7 @@ defmodule Spear do
       {:ok, Users.enable_resp()}
   """
   @doc since: "0.3.0"
+  @doc api: :utils
   @spec request(Spear.Connection.t(), module(), atom(), Enumerable.t(), Keyword.t()) ::
           {:ok, tuple() | Enumerable.t()} | {:error, any()}
   def request(conn, api, rpc, messages, opts) do
@@ -1015,6 +1035,8 @@ defmodule Spear do
   Parses an EventStoreDB timestamp into a `DateTime.t()` in UTC time.
   """
   @doc since: "0.3.0"
+  @doc api: :utils
+  @spec parse_stamp(pos_integer()) :: {:ok, DateTime.t()} | {:error, atom()}
   def parse_stamp(ticks_since_epoch) when is_integer(ticks_since_epoch) do
     ticks_since_epoch
     |> div(10)

--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -209,6 +209,152 @@ defmodule Spear.Client do
               opts :: Keyword.t()
             ) :: :ok | {:error, any()}
 
+  @doc """
+  A wrapper around `Spear.change_user_password/4`
+  """
+  @doc since: "0.3.0"
+  @callback change_user_password(
+              login_name :: String.t(),
+              current_password :: String.t(),
+              new_password :: String.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.change_user_password/5`
+  """
+  @doc since: "0.3.0"
+  @callback change_user_password(
+              login_name :: String.t(),
+              current_password :: String.t(),
+              new_password :: String.t(),
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.create_user/5`
+  """
+  @doc since: "0.3.0"
+  @callback create_user(
+              full_name :: String.t(),
+              login_name :: String.t(),
+              password :: String.t(),
+              groups :: [String.t()]
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.create_user/6`
+  """
+  @doc since: "0.3.0"
+  @callback create_user(
+              full_name :: String.t(),
+              login_name :: String.t(),
+              password :: String.t(),
+              groups :: [String.t()],
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.delete_user/2`
+  """
+  @doc since: "0.3.0"
+  @callback delete_user(login_name :: String.t()) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.delete_user/3`
+  """
+  @doc since: "0.3.0"
+  @callback delete_user(
+              login_name :: String.t(),
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.disable_user/2`
+  """
+  @doc since: "0.3.0"
+  @callback disable_user(login_name :: String.t()) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.disable_user/3`
+  """
+  @doc since: "0.3.0"
+  @callback disable_user(
+              login_name :: String.t(),
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.enable_user/2`
+  """
+  @doc since: "0.3.0"
+  @callback enable_user(login_name :: String.t()) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.enable_user/3`
+  """
+  @doc since: "0.3.0"
+  @callback enable_user(
+              login_name :: String.t(),
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.reset_user_password/3`
+  """
+  @doc since: "0.3.0"
+  @callback reset_user_password(
+              login_name :: String.t(),
+              new_password :: String.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.reset_user_password/4`
+  """
+  @doc since: "0.3.0"
+  @callback reset_user_password(
+              login_name :: String.t(),
+              new_password :: String.t(),
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.update_user/5`
+  """
+  @doc since: "0.3.0"
+  @callback update_user(
+              full_name :: String.t(),
+              login_name :: String.t(),
+              password :: String.t(),
+              groups :: [String.t()]
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.update_user/6`
+  """
+  @doc since: "0.3.0"
+  @callback update_user(
+              full_name :: String.t(),
+              login_name :: String.t(),
+              password :: String.t(),
+              groups :: [String.t()],
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.user_details/3`
+  """
+  @doc since: "0.3.0"
+  @callback user_details(login_name :: String.t()) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.user_details/3`
+  """
+  @doc since: "0.3.0"
+  @callback user_details(
+              login_name :: String.t(),
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
   @optional_callbacks start_link: 1
 
   defmacro __using__(opts) when is_list(opts) do
@@ -274,6 +420,46 @@ defmodule Spear.Client do
       @impl unquote(__MODULE__)
       def get_stream_metadata(stream, opts \\ []) do
         Spear.get_stream_metadata(__MODULE__, stream, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def change_user_password(login_name, current_password, new_password, opts \\ []) do
+        Spear.change_user_password(__MODULE__, login_name, current_password, new_password, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def create_user(full_name, login_name, password, groups, opts \\ []) do
+        Spear.create_user(__MODULE__, full_name, login_name, password, groups, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def delete_user(login_name, opts \\ []) do
+        Spear.delete_user(__MODULE__, login_name, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def disable_user(login_name, opts \\ []) do
+        Spear.disable_user(__MODULE__, login_name, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def enable_user(login_name, opts \\ []) do
+        Spear.enable_user(__MODULE__, login_name, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def reset_user_password(login_name, new_password, opts \\ []) do
+        Spear.reset_user_password(__MODULE__, login_name, new_password, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def update_user(full_name, login_name, password, groups, opts \\ []) do
+        Spear.update_user(__MODULE__, full_name, login_name, password, groups, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def user_details(login_name, opts \\ []) do
+        Spear.user_details(__MODULE__, login_name, opts)
       end
     end
   end

--- a/lib/spear/event.ex
+++ b/lib/spear/event.ex
@@ -407,12 +407,9 @@ defmodule Spear.Event do
   defp parse_created_stamp(nil), do: nil
 
   defp parse_created_stamp(stamp) when is_binary(stamp) do
-    significant_size = byte_size(stamp) - 1
-
-    with <<with_last_byte_cut::binary-size(significant_size), _::binary>> <- stamp,
-         {unix_stamp, <<>>} <- Integer.parse(with_last_byte_cut),
-         {:ok, parsed} <- DateTime.from_unix(unix_stamp, :microsecond) do
-      parsed
+    with {ticks_since_epoch, ""} <- Integer.parse(stamp),
+         {:ok, datetime} <- Spear.parse_stamp(ticks_since_epoch) do
+      datetime
     else
       _ -> nil
     end

--- a/lib/spear/grpc/response.ex
+++ b/lib/spear/grpc/response.ex
@@ -1,4 +1,4 @@
-alias Spear.{Connection.Response, Grpc}
+alias Spear.{Connection.Response, Grpc, Rpc}
 
 defmodule Grpc.Response do
   @moduledoc false
@@ -31,7 +31,7 @@ defmodule Grpc.Response do
     16 => :unauthenticated
   }
 
-  def from_connection_response(%Response{status: status}) when status != 200 do
+  def from_connection_response(%Response{status: status}, _request, _raw?) when status != 200 do
     %__MODULE__{
       status_code: 2,
       status: :unknown,
@@ -39,9 +39,9 @@ defmodule Grpc.Response do
     }
   end
 
-  def from_connection_response(%Response{type: type, headers: headers, data: data, status: 200}) do
+  def from_connection_response(%Response{headers: headers, data: data, status: 200}, rpc, raw?) do
     with {"grpc-status", "0"} <- List.keyfind(headers, "grpc-status", 0),
-         {parsed_data, <<>>} <- Grpc.decode_next_message(data, type) do
+         {:ok, parsed_data} <- parse_data(data, rpc, raw?) do
       %__MODULE__{
         status_code: 0,
         status: :ok,
@@ -62,12 +62,40 @@ defmodule Grpc.Response do
           data: data
         }
 
-      nil ->
+      _ ->
         %__MODULE__{
           status_code: 13,
           status: :internal,
           message: "Error parsing response proto"
         }
+    end
+  end
+
+  defp parse_data(data, rpc, raw?)
+
+  defp parse_data(data, _rpc, _raw? = true), do: {:ok, data}
+
+  defp parse_data(data, %Rpc{response_stream?: false} = rpc, _raw?) do
+    case Grpc.decode_next_message(data, {rpc.service_module, rpc.response_type}) do
+      {parsed, <<>>} -> {:ok, parsed}
+      _ -> :error
+    end
+  end
+
+  defp parse_data(data, %Rpc{response_stream?: true} = rpc, _raw?) do
+    import Spear.Records.Streams, only: [read_resp: 1, read_resp_stream_not_found: 0]
+
+    parse_chunk = &Spear.Grpc.decode_next_message(&1, {rpc.service_module, rpc.response_type})
+
+    case parse_chunk.(data) do
+      {read_resp(content: {:stream_not_found, read_resp_stream_not_found()}), _rest} ->
+        {:ok, []}
+
+      {_message, _rest} ->
+        {:ok, Stream.unfold(data, parse_chunk)}
+
+      _ ->
+        :error
     end
   end
 

--- a/lib/spear/grpc/response.ex
+++ b/lib/spear/grpc/response.ex
@@ -73,7 +73,7 @@ defmodule Grpc.Response do
 
   defp parse_data(data, rpc, raw?)
 
-  defp parse_data(data, _rpc, _raw? = true), do: {:ok, data}
+  defp parse_data(data, _rpc, true), do: {:ok, data}
 
   defp parse_data(data, %Rpc{response_stream?: false} = rpc, _raw?) do
     case Grpc.decode_next_message(data, {rpc.service_module, rpc.response_type}) do

--- a/lib/spear/reading.ex
+++ b/lib/spear/reading.ex
@@ -59,9 +59,7 @@ defmodule Spear.Reading do
       )
 
     %Spear.Request{
-      service: :"event_store.client.streams.Streams",
-      service_module: :spear_proto_streams,
-      rpc: :Read,
+      api: {Spear.Records.Streams, :Read},
       messages: [message],
       credentials: params.credentials
     }

--- a/lib/spear/reading/stream.ex
+++ b/lib/spear/reading/stream.ex
@@ -92,9 +92,7 @@ defmodule Spear.Reading.Stream do
 
   defp build_request(message, credentials) do
     %Spear.Request{
-      service: :"event_store.client.streams.Streams",
-      service_module: :spear_proto_streams,
-      rpc: :Read,
+      api: {Spear.Records.Streams, :Read},
       messages: [message],
       credentials: credentials
     }

--- a/lib/spear/reading/stream.ex
+++ b/lib/spear/reading/stream.ex
@@ -24,36 +24,21 @@ defmodule Spear.Reading.Stream do
     ]
 
   def new!(opts) do
+    opts = Keyword.put(opts, :max_count, opts[:chunk_size])
     state = struct(__MODULE__, opts)
     response = request!(state)
 
     wrap_buffer_in_decode_stream(
       state,
-      response.data,
+      response,
       &unfold_continuous/1
     )
   end
 
   @spec read_chunk(Keyword.t()) :: {:ok, Enumerable.t()} | {:error, any()}
   def read_chunk(opts) do
-    state = struct(__MODULE__, opts)
-
-    case request(state) do
-      {:ok, response} ->
-        stream =
-          wrap_buffer_in_decode_stream(
-            state,
-            response.data,
-            &unfold_chunk/1
-          )
-
-        {:ok, stream}
-
-      # coveralls-ignore-start
-      error ->
-        error
-        # coveralls-ignore-stop
-    end
+    struct(__MODULE__, opts)
+    |> request(_raw? = false)
   end
 
   def wrap_buffer_in_decode_stream(state, buffer, unfold_fn) do
@@ -74,34 +59,23 @@ defmodule Spear.Reading.Stream do
     end
   end
 
-  defp request(state) do
-    request = Reading.build_read_request(state)
+  defp request(state, raw?) do
+    read_request = Reading.build_read_request(state)
 
-    GenServer.call(
-      state.connection,
-      {:request, build_request(request, state.credentials)},
-      state.timeout
+    Spear.request(state.connection, Spear.Records.Streams, :Read, [read_request],
+      timeout: state.timeout,
+      credentials: state.credentials,
+      raw?: raw?
     )
   end
 
   defp request!(state) do
-    {:ok, response} = request(state)
+    {:ok, response} = request(state, _raw? = true)
 
     response
   end
 
-  defp build_request(message, credentials) do
-    %Spear.Request{
-      api: {Spear.Records.Streams, :Read},
-      messages: [message],
-      credentials: credentials
-    }
-    |> Spear.Request.expand()
-  end
-
-  @spec unfold_chunk(binary() | %__MODULE__{}) :: {struct(), binary()} | nil
-  def unfold_chunk(%__MODULE__{} = state), do: unfold_chunk(state.buffer)
-
+  @spec unfold_chunk(binary()) :: {struct(), binary()} | nil
   def unfold_chunk(buffer) when is_binary(buffer) do
     Spear.Grpc.decode_next_message(
       buffer,
@@ -115,7 +89,7 @@ defmodule Spear.Reading.Stream do
   defp unfold_continuous(%__MODULE__{buffer: <<>>, from: from} = state) do
     response = request!(%__MODULE__{state | max_count: state.max_count + 1})
 
-    case unfold_chunk(response.data) do
+    case unfold_chunk(response) do
       # discard the first message since it is `from`
       {^from, <<_head, _::binary>> = rest} ->
         unfold_continuous(%__MODULE__{state | buffer: rest})

--- a/lib/spear/records.ex
+++ b/lib/spear/records.ex
@@ -6,9 +6,6 @@ defmodule Spear.Records do
 
   @doc """
   a macro that extracts all records from the gpb generated .hrl files in src/
-  for a particular prefix
-
-  e.g. "event_store.client.streams."
 
   it turns them into little macros with Record.defrecord/2
   so they are easier to use/match-with in other files in Spear
@@ -21,7 +18,7 @@ defmodule Spear.Records do
 
   this is where that comes from!
   """
-  defmacro from_hrl(service_module) do
+  defmacro __using__(service_module: service_module) do
     quote do
       require Record
 
@@ -44,11 +41,13 @@ defmodule Spear.Records do
       @doc """
       Returns the `:gpb`-generated service module
       """
+      @impl unquote(__MODULE__)
       def service_module, do: unquote(service_module)
 
       @doc """
       Returns the gRPC service name for the API
       """
+      @impl unquote(__MODULE__)
       def service, do: service_module().get_service_names() |> List.first()
     end
   end

--- a/lib/spear/records.ex
+++ b/lib/spear/records.ex
@@ -41,8 +41,14 @@ defmodule Spear.Records do
         Record.defrecord(short_name, name, attrs)
       end
 
+      @doc """
+      Returns the `:gpb`-generated service module
+      """
       def service_module, do: unquote(service_module)
 
+      @doc """
+      Returns the gRPC service name for the API
+      """
       def service, do: service_module().get_service_names() |> List.first()
     end
   end

--- a/lib/spear/records/operations.ex
+++ b/lib/spear/records/operations.ex
@@ -1,0 +1,9 @@
+defmodule Spear.Records.Operations do
+  require Spear.Records
+
+  @moduledoc """
+  A record macro interface for interacting with the EventStoreDB Operations API
+  """
+
+  Spear.Records.from_hrl(:spear_proto_operations)
+end

--- a/lib/spear/records/operations.ex
+++ b/lib/spear/records/operations.ex
@@ -1,9 +1,7 @@
 defmodule Spear.Records.Operations do
-  require Spear.Records
-
   @moduledoc """
   A record macro interface for interacting with the EventStoreDB Operations API
   """
 
-  Spear.Records.from_hrl(:spear_proto_operations)
+  use Spear.Records, service_module: :spear_proto_operations
 end

--- a/lib/spear/records/persistent.ex
+++ b/lib/spear/records/persistent.ex
@@ -1,0 +1,9 @@
+defmodule Spear.Records.Persistent do
+  require Spear.Records
+
+  @moduledoc """
+  A record macro interface for interacting with the EventStoreDB Persistent Subscriptions API
+  """
+
+  Spear.Records.from_hrl(:spear_proto_persistent)
+end

--- a/lib/spear/records/persistent.ex
+++ b/lib/spear/records/persistent.ex
@@ -1,9 +1,7 @@
 defmodule Spear.Records.Persistent do
-  require Spear.Records
-
   @moduledoc """
   A record macro interface for interacting with the EventStoreDB Persistent Subscriptions API
   """
 
-  Spear.Records.from_hrl(:spear_proto_persistent)
+  use Spear.Records, service_module: :spear_proto_persistent
 end

--- a/lib/spear/records/projections.ex
+++ b/lib/spear/records/projections.ex
@@ -1,9 +1,7 @@
 defmodule Spear.Records.Projections do
-  require Spear.Records
-
   @moduledoc """
   A record macro interface for interacting with the EventStoreDB Projections API
   """
 
-  Spear.Records.from_hrl(:spear_proto_projections)
+  use Spear.Records, service_module: :spear_proto_projections
 end

--- a/lib/spear/records/projections.ex
+++ b/lib/spear/records/projections.ex
@@ -1,0 +1,9 @@
+defmodule Spear.Records.Projections do
+  require Spear.Records
+
+  @moduledoc """
+  A record macro interface for interacting with the EventStoreDB Projections API
+  """
+
+  Spear.Records.from_hrl(:spear_proto_projections)
+end

--- a/lib/spear/records/shared.ex
+++ b/lib/spear/records/shared.ex
@@ -1,9 +1,7 @@
 defmodule Spear.Records.Shared do
-  require Spear.Records
-
   @moduledoc """
   Shared record definitions for EventStoreDB messages
   """
 
-  Spear.Records.from_hrl(:spear_proto_shared)
+  use Spear.Records, service_module: :spear_proto_shared
 end

--- a/lib/spear/records/shared.ex
+++ b/lib/spear/records/shared.ex
@@ -5,8 +5,5 @@ defmodule Spear.Records.Shared do
   Shared record definitions for EventStoreDB messages
   """
 
-  Spear.Records.def_all_records(
-    "event_store.client.shared.",
-    "src/spear_proto_shared.hrl"
-  )
+  Spear.Records.from_hrl(:spear_proto_shared)
 end

--- a/lib/spear/records/streams.ex
+++ b/lib/spear/records/streams.ex
@@ -5,8 +5,5 @@ defmodule Spear.Records.Streams do
   A record macro interface for interacting with the EventStoreDB Streams API
   """
 
-  Spear.Records.def_all_records(
-    "event_store.client.streams.",
-    "src/spear_proto_streams.hrl"
-  )
+  Spear.Records.from_hrl(:spear_proto_streams)
 end

--- a/lib/spear/records/streams.ex
+++ b/lib/spear/records/streams.ex
@@ -1,9 +1,7 @@
 defmodule Spear.Records.Streams do
-  require Spear.Records
-
   @moduledoc """
   A record macro interface for interacting with the EventStoreDB Streams API
   """
 
-  Spear.Records.from_hrl(:spear_proto_streams)
+  use Spear.Records, service_module: :spear_proto_streams
 end

--- a/lib/spear/records/users.ex
+++ b/lib/spear/records/users.ex
@@ -1,9 +1,7 @@
 defmodule Spear.Records.Users do
-  require Spear.Records
-
   @moduledoc """
   A record macro interface for interacting with the EventStoreDB Users API
   """
 
-  Spear.Records.from_hrl(:spear_proto_users)
+  use Spear.Records, service_module: :spear_proto_users
 end

--- a/lib/spear/records/users.ex
+++ b/lib/spear/records/users.ex
@@ -1,0 +1,9 @@
+defmodule Spear.Records.Users do
+  require Spear.Records
+
+  @moduledoc """
+  A record macro interface for interacting with the EventStoreDB Users API
+  """
+
+  Spear.Records.from_hrl(:spear_proto_users)
+end

--- a/lib/spear/user.ex
+++ b/lib/spear/user.ex
@@ -36,12 +36,12 @@ defmodule Spear.User do
   """
   @typedoc since: "0.3.0"
   @type t :: %__MODULE__{
-    login_name: String.t(),
-    full_name: String.t(),
-    groups: [String.t()],
-    last_updated: DateTime.t(),
-    enabled?: boolean()
-  }
+          login_name: String.t(),
+          full_name: String.t(),
+          groups: [String.t()],
+          last_updated: DateTime.t(),
+          enabled?: boolean()
+        }
 
   defstruct ~w[login_name full_name groups last_updated enabled?]a
 

--- a/lib/spear/user.ex
+++ b/lib/spear/user.ex
@@ -1,0 +1,75 @@
+defmodule Spear.User do
+  @moduledoc """
+  A struct representing an EventStoreDB user
+
+  These are returned from `Spear.user_details/3`.
+  """
+  @moduledoc since: "0.3.0"
+
+  import Spear.Records.Users,
+    only: [
+      details_resp: 1,
+      details_resp_user_details: 1,
+      details_resp_user_details_date_time: 1
+    ]
+
+  @typedoc """
+  A struct representing an EventStoreDB user
+
+  The `:enabled?` flag controls whether or not a user may execute requests,
+  even with valid login information. This can be used to temporarily disable
+  a user as an alternative to deleting the user altogether.
+
+  ## Examples
+
+      iex> Spear.create_user(conn, "Aladdin", "aladdin", "open sesame", ["$ops"])
+      :ok
+      iex> Spear.user_details(conn, "aladdin")
+      {:ok,
+       %Spear.User{
+         enabled?: true,
+         full_name: "Aladdin",
+         groups: ["$ops"],
+         last_updated: ~U[2021-04-18 16:48:38.583313Z],
+         login_name: "aladdin"
+       }}
+  """
+  @typedoc since: "0.3.0"
+  @type t :: %__MODULE__{
+    login_name: String.t(),
+    full_name: String.t(),
+    groups: [String.t()],
+    last_updated: DateTime.t(),
+    enabled?: boolean()
+  }
+
+  defstruct ~w[login_name full_name groups last_updated enabled?]a
+
+  def from_details_resp(
+        details_resp(
+          user_details:
+            details_resp_user_details(
+              login_name: login_name,
+              full_name: full_name,
+              groups: groups,
+              last_updated:
+                details_resp_user_details_date_time(ticks_since_epoch: ticks_since_epoch),
+              disabled: disabled?
+            )
+        )
+      ) do
+    last_updated =
+      case Spear.parse_stamp(ticks_since_epoch) do
+        {:ok, datetime} -> datetime
+        _ -> nil
+      end
+
+    %__MODULE__{
+      login_name: login_name,
+      full_name: full_name,
+      groups: groups,
+      last_updated: last_updated,
+      enabled?: not disabled?
+    }
+  end
+end

--- a/lib/spear/writing.ex
+++ b/lib/spear/writing.ex
@@ -23,21 +23,7 @@ defmodule Spear.Writing do
 
   alias Spear.ExpectationViolation
 
-  def build_write_request(params) do
-    messages =
-      [build_append_request(params)]
-      |> Stream.concat(params.event_stream)
-      |> Stream.map(&to_append_request/1)
-
-    %Spear.Request{
-      api: {Spear.Records.Streams, :Append},
-      messages: messages,
-      credentials: params.credentials
-    }
-    |> Spear.Request.expand()
-  end
-
-  defp build_append_request(params) do
+  def build_append_request(params) do
     append_req(
       content:
         {:options,
@@ -93,11 +79,11 @@ defmodule Spear.Writing do
   defp map_expectation(:exists), do: {:stream_exists, empty()}
   defp map_expectation(_), do: {:any, empty()}
 
-  defp to_append_request(%Spear.Event{} = event) do
+  def to_append_request(%Spear.Event{} = event) do
     Spear.Event.to_proposed_message(event)
   end
 
-  defp to_append_request(append_req() = request), do: request
+  def to_append_request(append_req() = request), do: request
 
   # N.B. there are fields in here
   # - current_revision_option_20_6_0

--- a/lib/spear/writing.ex
+++ b/lib/spear/writing.ex
@@ -35,24 +35,6 @@ defmodule Spear.Writing do
   end
 
   def build_delete_request(%{tombstone?: false} = params) do
-    %Spear.Request{
-      api: {Spear.Records.Streams, :Delete},
-      messages: [build_delete_message(params)],
-      credentials: params.credentials
-    }
-    |> Spear.Request.expand()
-  end
-
-  def build_delete_request(%{tombstone?: true} = params) do
-    %Spear.Request{
-      api: {Spear.Records.Streams, :Tombstone},
-      messages: [build_delete_message(params)],
-      credentials: params.credentials
-    }
-    |> Spear.Request.expand()
-  end
-
-  defp build_delete_message(%{tombstone?: false} = params) do
     delete_req(
       options:
         delete_req_options(
@@ -62,7 +44,7 @@ defmodule Spear.Writing do
     )
   end
 
-  defp build_delete_message(%{tombstone?: true} = params) do
+  def build_delete_request(%{tombstone?: true} = params) do
     tombstone_req(
       options:
         tombstone_req_options(

--- a/lib/spear/writing.ex
+++ b/lib/spear/writing.ex
@@ -30,9 +30,7 @@ defmodule Spear.Writing do
       |> Stream.map(&to_append_request/1)
 
     %Spear.Request{
-      service: :"event_store.client.streams.Streams",
-      service_module: :spear_proto_streams,
-      rpc: :Append,
+      api: {Spear.Records.Streams, :Append},
       messages: messages,
       credentials: params.credentials
     }
@@ -52,9 +50,7 @@ defmodule Spear.Writing do
 
   def build_delete_request(%{tombstone?: false} = params) do
     %Spear.Request{
-      service: :"event_store.client.streams.Streams",
-      service_module: :spear_proto_streams,
-      rpc: :Delete,
+      api: {Spear.Records.Streams, :Delete},
       messages: [build_delete_message(params)],
       credentials: params.credentials
     }
@@ -63,9 +59,7 @@ defmodule Spear.Writing do
 
   def build_delete_request(%{tombstone?: true} = params) do
     %Spear.Request{
-      service: :"event_store.client.streams.Streams",
-      service_module: :spear_proto_streams,
-      rpc: :Tombstone,
+      api: {Spear.Records.Streams, :Tombstone},
       messages: [build_delete_message(params)],
       credentials: params.credentials
     }

--- a/mix.exs
+++ b/mix.exs
@@ -98,7 +98,11 @@ defmodule Spear.MixProject do
       groups_for_modules: [
         "Record interfaces": [
           Spear.Records.Shared,
-          Spear.Records.Streams
+          Spear.Records.Streams,
+          Spear.Records.Operations,
+          Spear.Records.Projections,
+          Spear.Records.Persistent,
+          Spear.Records.Users
         ]
       ],
       skip_undefined_reference_warnings_on: [

--- a/mix.exs
+++ b/mix.exs
@@ -115,13 +115,13 @@ defmodule Spear.MixProject do
         ]
       ],
       groups_for_functions: [
-        "Utility Functions": & &1[:api] == :utils,
-        Streams: & &1[:api] == :streams,
-        Users: & &1[:api] == :users,
-        Operations: & &1[:api] == :operations,
-        Projections: & &1[:api] == :projections,
-        "Persistent Subscriptions": & &1[:api] == :persistent,
-        Gossip: & &1[:api] == :gossip
+        "Utility Functions": &(&1[:api] == :utils),
+        Streams: &(&1[:api] == :streams),
+        Users: &(&1[:api] == :users),
+        Operations: &(&1[:api] == :operations),
+        Projections: &(&1[:api] == :projections),
+        "Persistent Subscriptions": &(&1[:api] == :persistent),
+        Gossip: &(&1[:api] == :gossip)
       ],
       skip_undefined_reference_warnings_on: [
         "CHANGELOG.md"

--- a/mix.exs
+++ b/mix.exs
@@ -96,6 +96,15 @@ defmodule Spear.MixProject do
         Guides: Path.wildcard("guides/*.md")
       ],
       groups_for_modules: [
+        "Structures and Types": [
+          Spear.Acl,
+          Spear.Connection.Configuration,
+          Spear.Event,
+          Spear.ExpectationViolation,
+          Spear.Filter.Checkpoint,
+          Spear.StreamMetadata,
+          Spear.User
+        ],
         "Record interfaces": [
           Spear.Records.Shared,
           Spear.Records.Streams,
@@ -104,6 +113,15 @@ defmodule Spear.MixProject do
           Spear.Records.Persistent,
           Spear.Records.Users
         ]
+      ],
+      groups_for_functions: [
+        "Utility Functions": & &1[:api] == :utils,
+        Streams: & &1[:api] == :streams,
+        Users: & &1[:api] == :users,
+        Operations: & &1[:api] == :operations,
+        Projections: & &1[:api] == :projections,
+        "Persistent Subscriptions": & &1[:api] == :persistent,
+        Gossip: & &1[:api] == :gossip
       ],
       skip_undefined_reference_warnings_on: [
         "CHANGELOG.md"

--- a/test/spear/connection_test.exs
+++ b/test/spear/connection_test.exs
@@ -52,6 +52,6 @@ defmodule Spear.ConnectionTest do
 
     send(conn, :crypto.strong_rand_bytes(16))
 
-    refute_receive _
+    refute_receive _, 500
   end
 end

--- a/test/spear/grpc/response_test.exs
+++ b/test/spear/grpc/response_test.exs
@@ -13,7 +13,7 @@ defmodule Spear.Grpc.ResponseTest do
   test "a non-200 status code connection response is converted to an error code 2" do
     grpc_response =
       %Connection.Response{status: 404, headers: []}
-      |> Grpc.Response.from_connection_response()
+      |> Grpc.Response.from_connection_response(%Spear.Rpc{}, false)
 
     assert grpc_response.status_code == 2
     assert grpc_response.status == :unknown
@@ -27,7 +27,13 @@ defmodule Spear.Grpc.ResponseTest do
 
     grpc_response =
       %Connection.Response{status: 200, headers: [], type: ReadResp, data: buffer}
-      |> Grpc.Response.from_connection_response()
+      |> Grpc.Response.from_connection_response(
+        %Spear.Rpc{
+          response_type: ReadResp,
+          service_module: :spear_proto_streams
+        },
+        false
+      )
 
     assert grpc_response.status_code == 13
     assert grpc_response.status == :internal

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+# defaults to 100 & 100
+ExUnit.configure(assert_receive_timeout: 1_000, refute_receive_timeout: 300)
 ExUnit.start()


### PR DESCRIPTION
connects #7 

did myself a wee favor in this PR by refactoring some fragmented code like timestamp parsing and making a centralized `Spear.request/5` function for synchronous requests

should make the rest of the protos a little bit easier to wrap

this one was one of the largest that remain so hopefully it's all downhill from here until persistent subscriptions