### PR TITLE
implement the crud portion of the persistent subscription API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - [Unreleased]
+
+### Added
+
+- Added the persistent subscriptions API
+    - `Spear.create_persistent_subscription/5`
+    - `Spear.update_persistent_subscription/5`
+    - `Spear.delete_persistent_subscription/4`
+    - `Spear.list_persistent_subscriptions/2`
+    - associated callbacks in `Spear.Client`
+
 ## 0.5.0 - 2021-04-19
 
 ### Added

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -1579,4 +1579,42 @@ defmodule Spear do
         # coveralls-ignore-stop
     end
   end
+
+  @doc """
+  Deletes a persistent subscription from the EventStoreDB
+
+  Persistent subscriptions are considered unique by their stream and group
+  names together: you may define separate persistent subscriptions for the same
+  stream with multiple groups or use the same group name for persistent
+  subscriptions to multiple streams. A combination of stream name and group
+  name together is considered unique though.
+
+  ## Options
+
+  Options are passed to `request/5`.
+
+  ## Examples
+
+      iex> Spear.delete_persistent_subscription(conn, "my_stream", "MyGroup")
+      :ok
+  """
+  @doc since: "0.6.0"
+  @doc api: :persistent
+  @spec delete_persistent_subscription(connection :: Spear.Connection.t(), stream_name :: String.t(), group_name :: String.t(), opts :: Keyword.t()) :: :ok | {:error, any()}
+  def delete_persistent_subscription(conn, stream_name, group_name, opts \\ [])
+
+  def delete_persistent_subscription(conn, stream_name, group_name, opts) when is_binary(stream_name) and is_binary(group_name) do
+    message =
+      Persistent.delete_req(options:
+        Persistent.delete_req_options(
+          stream_identifier: Shared.stream_identifier(streamName: stream_name),
+          group_name: group_name
+        )
+      )
+
+    case request(conn, Persistent, :Delete, [message], opts) do
+      {:ok, Persistent.delete_resp()} -> :ok
+      error -> error
+    end
+  end
 end

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -69,17 +69,17 @@ defmodule Spear do
     Streams,
     Users,
     Operations,
-    Gossip
-    # Persistent,
-    # Shared
+    Gossip,
+    Persistent,
+    Shared
   }
 
   require Streams
   require Users
   require Operations
   require Gossip
-  # require Persistent
-  # require Shared
+  require Persistent
+  require Shared
 
   @doc """
   Collects an EventStoreDB stream into an enumerable

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -1642,4 +1642,180 @@ defmodule Spear do
       error -> error
     end
   end
+
+  @doc """
+  Creates a persistent subscription
+
+  See `t:Spear.PersistentSubscription.Settings.t/0` for more information.
+
+  ## Options
+
+  Options are passed to `request/5`.
+
+  ## Examples
+
+      iex> Spear.create_persistent_subscription(conn, "my_stream", "my_group", %Spear.PersistentSubscription.Settings{})
+      :ok
+  """
+  @doc since: "0.6.0"
+  @doc api: :persistent
+  @spec create_persistent_subscription(
+          connection :: Spear.Connection.t(),
+          stream_name :: String.t(),
+          group_name :: String.t(),
+          settings :: Spear.PersistentSubscription.Settings.t(),
+          opts :: Keyword.t()
+        ) :: :ok | {:error, any()}
+  def create_persistent_subscription(conn, stream_name, group_name, settings, opts \\ [])
+
+  def create_persistent_subscription(
+        conn,
+        stream_name,
+        group_name,
+        %Spear.PersistentSubscription.Settings{} = settings,
+        opts
+      )
+      when is_binary(stream_name) and is_binary(group_name) do
+    message =
+      Persistent.create_req(
+        options:
+          Persistent.create_req_options(
+            stream_identifier: Shared.stream_identifier(streamName: stream_name),
+            group_name: group_name,
+            settings: Spear.PersistentSubscription.Settings.to_record(settings, :create)
+          )
+      )
+
+    case request(conn, Persistent, :Create, [message], opts) do
+      {:ok, Persistent.create_resp()} -> :ok
+      error -> error
+    end
+  end
+
+  @doc """
+  Updates an existing persistent subscription
+
+  See `t:Spear.PersistentSubscription.Settings.t/0` for more information.
+
+  ## Options
+
+  Options are passed to `request/5`.
+
+  ## Examples
+
+      iex> Spear.update_persistent_subscription(conn, "my_stream", "my_group", %Spear.PersistentSubscription.Settings{})
+      :ok
+  """
+  @doc since: "0.6.0"
+  @doc api: :persistent
+  @spec update_persistent_subscription(
+          connection :: Spear.Connection.t(),
+          stream_name :: String.t(),
+          group_name :: String.t(),
+          settings :: Spear.PersistentSubscription.Settings.t(),
+          opts :: Keyword.t()
+        ) :: :ok | {:error, any()}
+  def update_persistent_subscription(conn, stream_name, group_name, settings, opts \\ [])
+
+  def update_persistent_subscription(
+        conn,
+        stream_name,
+        group_name,
+        %Spear.PersistentSubscription.Settings{} = settings,
+        opts
+      )
+      when is_binary(stream_name) and is_binary(group_name) do
+    message =
+      Persistent.update_req(
+        options:
+          Persistent.update_req_options(
+            stream_identifier: Shared.stream_identifier(streamName: stream_name),
+            group_name: group_name,
+            settings: Spear.PersistentSubscription.Settings.to_record(settings, :update)
+          )
+      )
+
+    case request(conn, Persistent, :Update, [message], opts) do
+      {:ok, Persistent.update_resp()} -> :ok
+      error -> error
+    end
+  end
+
+  @doc """
+  Lists the currently existing persistent subscriptions
+
+  Results are returned in an `t:Enumerable.t/0` of
+  `t:Spear.PersistentSubscription.t/0`.
+
+  Note that the `:extra_statistics?` field of settings is not determined by
+  this function: `:extra_statistics?` will always be returned as `nil` in this
+  function.
+
+  This function works by reading the built-in `$persistentSubscriptionConfig`
+  stream. This stream can be read normally to obtain additional information
+  such as at timestamp for the last time the persistent subscription config was
+  updated.
+
+  ## Options
+
+  Options are passed to `read_stream/3`. `:direction`, `:from`, and
+  `:max_count` are fixed and cannot be overridden.
+
+  ## Examples
+
+
+      iex> Spear.create_persistent_subscription(conn, "my_stream", "my_group", %Spear.PersistentSubscription.Settings{})
+      :ok
+      iex> {:ok, subscriptions} = Spear.list_persistent_subscriptions(conn)
+      iex> subscriptions |> Enum.to_list()
+      [
+        %Spear.PersistentSubscription{
+          group_name: "my_group",
+          settings: %Spear.PersistentSubscription.Settings{
+            checkpoint_after: 3000,
+            extra_statistics?: nil,
+            history_buffer_size: 300,
+            live_buffer_size: 100,
+            max_checkpoint_count: 100,
+            max_retry_count: 10,
+            max_subscriber_count: 1,
+            message_timeout: 5000,
+            min_checkpoint_count: 1,
+            named_consumer_strategy: :RoundRobin,
+            read_batch_size: 100,
+            resolve_links?: true,
+            revision: 0
+          },
+          stream_name: "my_stream"
+        }
+      ]
+  """
+  @doc since: "0.6.0"
+  @doc api: :persistent
+  @spec list_persistent_subscriptions(connection :: Spear.Connection.t(), opts :: Keyword.t()) ::
+          {:ok, Enumerable.t()} | {:error, any()}
+  def list_persistent_subscriptions(conn, opts \\ []) do
+    read_opts =
+      opts
+      |> Keyword.merge(
+        direction: :backwards,
+        from: :end,
+        max_count: 1
+      )
+
+    case read_stream(conn, "$persistentSubscriptionConfig", read_opts) do
+      {:ok, stream} ->
+        subscriptions =
+          stream
+          |> Stream.flat_map(&get_in(&1, [Access.key(:body), "entries"]))
+          |> Stream.map(&Spear.PersistentSubscription.from_map/1)
+
+        {:ok, subscriptions}
+
+      # coveralls-ignore-start
+      error ->
+        error
+        # coveralls-ignore-stop
+    end
+  end
 end

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -1618,16 +1618,23 @@ defmodule Spear do
   """
   @doc since: "0.6.0"
   @doc api: :persistent
-  @spec delete_persistent_subscription(connection :: Spear.Connection.t(), stream_name :: String.t(), group_name :: String.t(), opts :: Keyword.t()) :: :ok | {:error, any()}
+  @spec delete_persistent_subscription(
+          connection :: Spear.Connection.t(),
+          stream_name :: String.t(),
+          group_name :: String.t(),
+          opts :: Keyword.t()
+        ) :: :ok | {:error, any()}
   def delete_persistent_subscription(conn, stream_name, group_name, opts \\ [])
 
-  def delete_persistent_subscription(conn, stream_name, group_name, opts) when is_binary(stream_name) and is_binary(group_name) do
+  def delete_persistent_subscription(conn, stream_name, group_name, opts)
+      when is_binary(stream_name) and is_binary(group_name) do
     message =
-      Persistent.delete_req(options:
-        Persistent.delete_req_options(
-          stream_identifier: Shared.stream_identifier(streamName: stream_name),
-          group_name: group_name
-        )
+      Persistent.delete_req(
+        options:
+          Persistent.delete_req_options(
+            stream_identifier: Shared.stream_identifier(streamName: stream_name),
+            group_name: group_name
+          )
       )
 
     case request(conn, Persistent, :Delete, [message], opts) do

--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -457,6 +457,80 @@ defmodule Spear.Client do
   @doc since: "0.5.0"
   @callback cluster_info(opts :: Keyword.t()) :: :ok | {:error, any()}
 
+  @doc """
+  A wrapper around `Spear.create_persistent_subscription/4`
+  """
+  @doc since: "0.6.0"
+  @callback create_persistent_subscription(
+              stream_name :: String.t(),
+              group_name :: String.t(),
+              settings :: Spear.PersistentSubscription.Settings.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.create_persistent_subscription/5`
+  """
+  @doc since: "0.6.0"
+  @callback create_persistent_subscription(
+              stream_name :: String.t(),
+              group_name :: String.t(),
+              settings :: Spear.PersistentSubscription.Settings.t(),
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.update_persistent_subscription/4`
+  """
+  @doc since: "0.6.0"
+  @callback update_persistent_subscription(
+              stream_name :: String.t(),
+              group_name :: String.t(),
+              settings :: Spear.PersistentSubscription.Settings.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.update_persistent_subscription/5`
+  """
+  @doc since: "0.6.0"
+  @callback update_persistent_subscription(
+              stream_name :: String.t(),
+              group_name :: String.t(),
+              settings :: Spear.PersistentSubscription.Settings.t(),
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.delete_persistent_subscription/3`
+  """
+  @doc since: "0.6.0"
+  @callback delete_persistent_subscription(
+              stream_name :: String.t(),
+              group_name :: String.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.delete_persistent_subscription/4`
+  """
+  @doc since: "0.6.0"
+  @callback delete_persistent_subscription(
+              stream_name :: String.t(),
+              group_name :: String.t(),
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.list_persistent_subscriptions/1`
+  """
+  @doc since: "0.6.0"
+  @callback list_persistent_subscriptions() :: {:ok, Enumerable.t()} | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.list_persistent_subscriptions/2`
+  """
+  @doc since: "0.6.0"
+  @callback list_persistent_subscriptions(opts :: Keyword.t()) ::
+              {:ok, Enumerable.t()} | {:error, any()}
+
   @optional_callbacks start_link: 1
 
   defmacro __using__(opts) when is_list(opts) do
@@ -602,6 +676,26 @@ defmodule Spear.Client do
       @impl unquote(__MODULE__)
       def cluster_info(opts \\ []) do
         Spear.cluster_info(__MODULE__, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def create_persistent_subscription(stream_name, group_name, settings, opts \\ []) do
+        Spear.create_persistent_subscription(__MODULE__, stream_name, group_name, settings, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def update_persistent_subscription(stream_name, group_name, settings, opts \\ []) do
+        Spear.update_persistent_subscription(__MODULE__, stream_name, group_name, settings, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def delete_persistent_subscription(stream_name, group_name, opts \\ []) do
+        Spear.delete_persistent_subscription(__MODULE__, stream_name, group_name, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def list_persistent_subscriptions(opts \\ []) do
+        Spear.list_persistent_subscriptions(__MODULE__, opts)
       end
     end
   end

--- a/lib/spear/persistent_subscription.ex
+++ b/lib/spear/persistent_subscription.ex
@@ -1,0 +1,77 @@
+defmodule Spear.PersistentSubscription do
+  @moduledoc """
+  A struct representing a persistent subscription and its settings
+  """
+
+  @typedoc """
+  A persistent subscription.
+
+  These are generally returned from `Spear.list_persistent_subscriptions/2`.
+
+  Persistent subscriptions are considered unique by their stream name and
+  group name pairings. A stream may have many different persistent
+  subscriptions with different group names and settings and a group name
+  may be used for multiple subscriptions to different streams.
+
+  ## Examples
+
+      iex> Spear.create_persistent_subscription(conn, "my_stream", "my_group", %Spear.PersistentSubscription.Settings{})
+      :ok
+      iex> {:ok, subscriptions} = Spear.list_persistent_subscriptions(conn)
+      iex> subscriptions |> Enum.to_list()
+      [
+        %Spear.PersistentSubscription{
+          group_name: "my_group",
+          settings: %Spear.PersistentSubscription.Settings{
+            checkpoint_after: 3000,
+            extra_statistics?: nil,
+            history_buffer_size: 300,
+            live_buffer_size: 100,
+            max_checkpoint_count: 100,
+            max_retry_count: 10,
+            max_subscriber_count: 1,
+            message_timeout: 5000,
+            min_checkpoint_count: 1,
+            named_consumer_strategy: :RoundRobin,
+            read_batch_size: 100,
+            resolve_links?: true,
+            revision: 0
+          },
+          stream_name: "my_stream"
+        }
+      ]
+  """
+  @typedoc since: "0.6.0"
+  @type t :: %__MODULE__{
+          stream_name: String.t(),
+          group_name: String.t(),
+          settings: Spear.PersistentSubscription.Settings.t()
+        }
+
+  defstruct ~w[stream_name group_name settings]a
+
+  @doc false
+  def from_map(map) do
+    %__MODULE__{
+      stream_name: map["stream"],
+      group_name: map["group"],
+      settings: %Spear.PersistentSubscription.Settings{
+        resolve_links?: map["resolveLinkTos"],
+        extra_statistics?: nil,
+        message_timeout: map["messageTimeout"],
+        live_buffer_size: map["liveBufferSize"],
+        history_buffer_size: map["historyBufferSize"],
+        max_retry_count: map["maxRetryCount"],
+        read_batch_size: map["readBatchSize"],
+        checkpoint_after: map["checkPointAfter"],
+        min_checkpoint_count: map["minCheckPointCount"],
+        max_checkpoint_count: map["maxCheckPointCount"],
+        max_subscriber_count: map["maxSubscriberCount"],
+        named_consumer_strategy: map["namedConsumerStrategy"] |> to_atom()
+      }
+    }
+  end
+
+  defp to_atom(string) when is_binary(string), do: String.to_atom(string)
+  defp to_atom(_), do: nil
+end

--- a/lib/spear/persistent_subscription/settings.ex
+++ b/lib/spear/persistent_subscription/settings.ex
@@ -1,0 +1,109 @@
+# credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
+defmodule Spear.PersistentSubscription.Settings do
+  @moduledoc """
+  A struct representing possible settings for a persistent subscription
+  """
+
+  @typedoc """
+  Possible values for consumer strategies
+
+  The consumer strategy controls how messages are distributed to multiple
+  subscribers. The setting has no effect for single-subscriber persistent
+  subscriptions.
+  """
+  @typedoc since: "0.6.0"
+  @type consumer_strategy() :: :RoundRobin | :Pinned | :DispatchToSingle
+
+  @typedoc """
+  Settings for a persistent subscription
+
+  See the EventStoreDB documentation for more information on each setting.
+
+  The defaults for this struct are set up for a simple case of a single
+  subscriber process.
+
+  `:message_timeout` and `:checkpoint_after` may either be specified as
+  `{:ticks, ticks}` or any integer where the ticks denote the EventStoreDB
+  tick timing. Integers are read as durations in milliseconds.
+  """
+  @typedoc since: "0.6.0"
+  @type t :: %__MODULE__{
+          resolve_links?: boolean(),
+          revision: non_neg_integer(),
+          extra_statistics?: boolean() | nil,
+          max_retry_count: non_neg_integer(),
+          min_checkpoint_count: pos_integer(),
+          max_checkpoint_count: pos_integer(),
+          max_subscriber_count: pos_integer(),
+          live_buffer_size: pos_integer(),
+          read_batch_size: pos_integer(),
+          history_buffer_size: pos_integer(),
+          named_consumer_strategy: consumer_strategy(),
+          message_timeout: {:ticks, pos_integer()} | pos_integer(),
+          checkpoint_after: {:ticks, pos_integer()} | pos_integer()
+        }
+
+  defstruct resolve_links?: true,
+            revision: 0,
+            extra_statistics?: false,
+            max_retry_count: 10,
+            min_checkpoint_count: 1,
+            max_checkpoint_count: 100,
+            max_subscriber_count: 1,
+            live_buffer_size: 100,
+            read_batch_size: 100,
+            history_buffer_size: 300,
+            named_consumer_strategy: :RoundRobin,
+            message_timeout: 5_000,
+            checkpoint_after: 3_000
+
+  import Spear.Records.Persistent
+
+  @doc false
+  def to_record(settings, opration)
+
+  def to_record(%__MODULE__{} = settings, :create) do
+    create_req_settings(
+      resolve_links: settings.resolve_links?,
+      revision: settings.revision,
+      extra_statistics: settings.extra_statistics?,
+      max_retry_count: settings.max_retry_count,
+      min_checkpoint_count: settings.min_checkpoint_count,
+      max_checkpoint_count: settings.max_checkpoint_count,
+      max_subscriber_count: settings.max_subscriber_count,
+      live_buffer_size: settings.live_buffer_size,
+      read_batch_size: settings.read_batch_size,
+      history_buffer_size: settings.history_buffer_size,
+      named_consumer_strategy: settings.named_consumer_strategy,
+      message_timeout: map_message_timeout(settings.message_timeout),
+      checkpoint_after: map_checkpoint_after(settings.checkpoint_after)
+    )
+  end
+
+  def to_record(%__MODULE__{} = settings, :update) do
+    update_req_settings(
+      resolve_links: settings.resolve_links?,
+      revision: settings.revision,
+      extra_statistics: settings.extra_statistics?,
+      max_retry_count: settings.max_retry_count,
+      min_checkpoint_count: settings.min_checkpoint_count,
+      max_checkpoint_count: settings.max_checkpoint_count,
+      max_subscriber_count: settings.max_subscriber_count,
+      live_buffer_size: settings.live_buffer_size,
+      read_batch_size: settings.read_batch_size,
+      history_buffer_size: settings.history_buffer_size,
+      named_consumer_strategy: settings.named_consumer_strategy,
+      message_timeout: map_message_timeout(settings.message_timeout),
+      checkpoint_after: map_checkpoint_after(settings.checkpoint_after)
+    )
+  end
+
+  # coveralls-ignore-start
+  defp map_message_timeout({:ticks, ticks}), do: {:message_timeout_ticks, ticks}
+  defp map_message_timeout(ms) when is_integer(ms), do: {:message_timeout_ms, ms}
+
+  defp map_checkpoint_after({:ticks, ticks}), do: {:checkpoint_after_ticks, ticks}
+  defp map_checkpoint_after(ms) when is_integer(ms), do: {:checkpoint_after_ms, ms}
+
+  # coveralls-ignore-stop
+end

--- a/mix.exs
+++ b/mix.exs
@@ -105,7 +105,9 @@ defmodule Spear.MixProject do
           Spear.StreamMetadata,
           Spear.User,
           Spear.ClusterMember,
-          Spear.Scavenge
+          Spear.Scavenge,
+          Spear.PersistentSubscription,
+          Spear.PersistentSubscription.Settings
         ],
         "Record interfaces": [
           Spear.Records.Shared,


### PR DESCRIPTION
connects #7 

simple crud stuffs for creating listing updating and deleting psubs

doesn't implement the real meat of the psub API which is the subscribing

the subscription part will probably necessitate changes to the `Spear.Connection` to allow a bi-directional subscription (current subscriptions asynchronously stream which is a good start but it's only in one direction: server->client. psubs will need to stream both directions), so I'm punting that to the next PR