### PR TITLE
implement subscription, acks & nacks in persistent subscriptions API

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,5 +1,5 @@
 make_server = fn ->
-  _sucure_params = [
+  secure_params = [
     connection_string: "esdb://admin:changeit@localhost:2113?tls=true",
     mint_opts: [
       transport_opts: [
@@ -8,11 +8,11 @@ make_server = fn ->
     ]
   ]
 
-  insecure_params = [
+  _insecure_params = [
     connection_string: "esdb://localhost:2113"
   ]
 
-  {:ok, pid} = Spear.Connection.start_link(insecure_params)
+  {:ok, pid} = Spear.Connection.start_link(secure_params)
 
   pid
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 - [Unreleased]
+## 0.6.0 - 2021-04-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Added
 
-- Added the persistent subscriptions API
+- Added the CRUD portions of persistent subscriptions API
     - `Spear.create_persistent_subscription/5`
     - `Spear.update_persistent_subscription/5`
     - `Spear.delete_persistent_subscription/4`
     - `Spear.list_persistent_subscriptions/2`
+    - associated callbacks in `Spear.Client`
+- Added subscription functionality for persistent subscriptions
+    - `Spear.connect_to_persistent_subscription/5`
+    - `Spear.ack/3`
+    - `Spear.nack/4`
     - associated callbacks in `Spear.Client`
 
 ## 0.5.0 - 2021-04-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
     - `Spear.nack/4`
     - associated callbacks in `Spear.Client`
 
+### Changed
+
+- Moved `Spear.cancel_subscription/3` under the utils API instead of streams
+    - This function may also be used to cancel persistent subscriptions
+
 ## 0.5.0 - 2021-04-19
 
 ### Added

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -452,6 +452,10 @@ defmodule Spear do
   subscription process must re-subscribe from the last received event or
   checkpoint to resume the subscription.
 
+  Subscriptions can be gracefully shut down with `Spear.cancel_subscription/3`.
+  The subscription will be cancelled by the connection process if the
+  subscriber process exits.
+
   ## Options
 
   * `:from` - (default: `:start`) the EventStoreDB stream revision from which to
@@ -566,7 +570,7 @@ defmodule Spear do
       :ok
   """
   @doc since: "0.1.0"
-  @doc api: :streams
+  @doc api: :utils
   @spec cancel_subscription(
           connection :: Spear.Connection.t(),
           subscription_reference :: reference(),
@@ -1817,5 +1821,301 @@ defmodule Spear do
         error
         # coveralls-ignore-stop
     end
+  end
+
+  @doc """
+  Subscribes a process to an existing persistent subscription
+
+  Persistent subscriptions can be gracefully closed with
+  `cancel_subscription/3` just like subscriptions started with `subscribe/4`.
+  The subscription will be cancelled by the connection process if the
+  subscriber process exits.
+
+  Persistent subscriptions are an alternative to standard subscriptions
+  (via `subscribe/4`) which use `ack/3` and `nack/4` to exert backpressure
+  and allow out-of-order and batch processing within a single consumer
+  and allow multiple connected consumers at once.
+
+  In standard subscriptions (via `subscribe/4`), if a client wishes to
+  handle events in order without reprocessing, the client must keep track
+  of its own position in a stream, either in memory or using some sort of
+  persistence such as PostgreSQL or mnesia for durability.
+
+  In contrast, persistent subscriptions are stateful on the server-side:
+  the EventStoreDB will keep track of which events have been positively and
+  negatively acknowledged and will only emit events which have not yet
+  been processed to any connected consumers.
+
+  This allows one to connect multiple subscriber processes to a persistent
+  subscription stream-group combination in a strategy called [Competing
+  Consumers](https://docs.microsoft.com/en-us/azure/architecture/patterns/competing-consumers).
+
+  Note that persistent subscription events are not guaranteed to be processed
+  in order like the standard subscriptions because of the ability to `nack/4`
+  and reprocess or park a message. While this requires special considerations
+  when authoring a consumer, it allows one to easily write a consumer which
+  does not head-of-line block in failure cases.
+
+  The subscriber will receive a message `{:eos, reason}` when the
+  subscription is closed by the server. Currently the only `reason` is
+  `:closed`.
+
+  ## Backpressure
+
+  Persistent subscriptions allow the subscriber process to exert backpressure
+  on the EventStoreDB so that the message queue is not flooded. This is
+  implemented with a buffer of events which are considered by the EventStoreDB
+  to be _in-flight_ when they are sent to the client. Events remain in-flight
+  until they are `ack/3`-ed, `nack/4`-ed, or until the `:message_timeout`
+  duration is exceeded. If a client `ack/3`s a message, the EventStoreDB
+  will send a new message if any are available.
+
+  The in-flight buffer size is controllable per subscriber through
+  `:buffer_size`. Note that `:message_timeout` applies to each event: if
+  the `:buffer_size` is 5 and five events arrive simultaneously, the client
+  has the duration `:message_timeout` to acknowledge all five events before
+  they are considered stale and are automatically considered nack-ed by
+  the EventStoreDB.
+
+  The `:buffer_size` should align with the consumer's ability to batch
+  process events.
+
+  ## Options
+
+  * `:timeout` - (default: `5_000`ms - 5s) the time to await a subscription
+    confirmation from the EventStoreDB.
+  * `:raw?` - (default: `false`) controls whether events are translated from
+    low-level `Spear.Records.Persistent.read_resp/0` records to
+    `t:Spear.Event.t/0`s. By default `t:Spear.Event.t/0`s are sent to the
+    subscriber.
+  * `:credentials` - (default: `nil`) the credentials to use to connect to the
+    subscription. When not specified, the connection-level credentials are
+    used. Credentials must be a two-tuple `{username, password}`.
+  * `:buffer_size` - (default: `1`) the number of events allowed to be sent
+    to the client at a time. These events are considered in-flight. See the
+    backpressure section above for more information.
+
+  ## Examples
+
+      iex> Spear.connect_to_persistent_subscription(conn, self(), "my_stream", "my_group")
+      iex> flush
+      %Spear.Event{}
+      :ok
+  """
+  @doc since: "0.6.0"
+  @doc api: :persistent
+  @spec connect_to_persistent_subscription(
+          connection :: Spear.Connection.t(),
+          subscriber :: pid() | GenServer.name(),
+          stream_name :: String.t(),
+          group_name :: String.t(),
+          opts :: Keyword.t()
+        ) :: {:ok, subscription :: reference()} | {:error, any()}
+  def connect_to_persistent_subscription(conn, subscriber, stream_name, group_name, opts \\ [])
+
+  def connect_to_persistent_subscription(conn, subscriber, stream_name, group_name, opts)
+      when is_binary(stream_name) and is_binary(group_name) do
+    default_subscribe_opts = [
+      timeout: 5_000,
+      raw?: false,
+      through: &Spear.Reading.decode_read_response/1,
+      credentials: nil,
+      buffer_size: 1
+    ]
+
+    opts =
+      default_subscribe_opts
+      |> Keyword.merge(opts)
+      |> Keyword.merge(stream: stream_name, subscriber: subscriber)
+
+    message =
+      Persistent.read_req(
+        content:
+          {:options,
+           Persistent.read_req_options(
+             stream_identifier: Shared.stream_identifier(streamName: stream_name),
+             group_name: group_name,
+             buffer_size: opts[:buffer_size],
+             uuid_option: Persistent.read_req_options_uuid_option(content: {:string, empty()})
+           )}
+      )
+
+    through =
+      if opts[:raw?] do
+        & &1
+      else
+        opts[:through]
+      end
+
+    request =
+      %Spear.Request{
+        api: {Persistent, :Read},
+        messages: [message],
+        credentials: opts[:credentials]
+      }
+      |> Spear.Request.expand()
+
+    # YARD deal with broken subscriptions
+    Connection.call(conn, {{:subscription, subscriber, through}, request}, opts[:timeout])
+  end
+
+  @doc """
+  Acknowledges that an event received as part of a persistent subscription was
+  successfully handled
+
+  Although `ack/3` can accept a `t:Spear.Event.t/0` alone, the underlying
+  gRPC call acknowledges a batch of event IDs.
+
+  ```elixir
+  Spear.ack(conn, subscription, events |> Enum.map(& &1.id))
+  ```
+
+  should be preferred over
+
+  ```elixir
+  Enum.each(events, &Spear.ack(conn, subscription, &1.id))
+  ```
+
+  As the acknowledgements will be batched.
+
+  This function (and `nack/4`) are asynchronous casts to the connection
+  process.
+
+  ## Examples
+
+      # some stream with 3 events
+      stream_name = "my_stream"
+      group_name = "spear_iex"
+      settings = %Spear.PersistentSubscription.Settings{}
+
+      get_event_and_ack = fn conn, sub ->
+        receive do
+          %Spear.Event{} = event ->
+            :ok = Spear.ack(conn, sub, event)
+
+            event
+
+        after
+          3_000 -> :no_events
+        end
+      end
+
+      iex> Spear.create_persistent_subscription(conn, stream_name, group_name, settings)
+      :ok
+      iex> {:ok, sub} = Spear.connect_to_persistent_subscription(conn, self(), stream_name, group_name)
+      iex> get_event_and_ack.(conn, sub)
+      %Spear.Event{..}
+      iex> get_event_and_ack.(conn, sub)
+      %Spear.Event{..}
+      iex> get_event_and_ack.(conn, sub)
+      %Spear.Event{..}
+      iex> get_event_and_ack.(conn, sub)
+      :no_events
+      iex> Spear.cancel_subscription(conn, sub)
+      :ok
+  """
+  @doc since: "0.6.0"
+  @doc api: :persistent
+  @spec ack(
+          connection :: Spear.Connection.t(),
+          subscription :: reference(),
+          event_or_ids :: Spear.Event.t() | [String.t()]
+        ) :: :ok
+  def ack(conn, subscription, event_or_ids)
+
+  def ack(conn, sub, %Spear.Event{id: id}), do: ack(conn, sub, [id])
+
+  def ack(conn, sub, event_ids) when is_list(event_ids) do
+    id = ""
+    ids = Enum.map(event_ids, fn id -> Shared.uuid(value: {:string, id}) end)
+    # YARD this id field may be incorrect
+    message = Persistent.read_req(content: {:ack, Persistent.read_req_ack(id: id, ids: ids)})
+
+    Connection.cast(conn, {:push, sub, message})
+  end
+
+  @doc """
+  Negatively acknowldeges a persistent subscription event
+
+  Nacking is the opposite of `ack/3`ing: it tells the EventStoreDB that the
+  event should not be considered processed.
+
+  ## Options
+
+  * `:action` - (default: `:retry`) controls the action the EventStoreDB
+    should take about the event. See
+    `t:Spear.PersistentSubscription.nack_action/0` for a full description.
+  * `:reason` - (default: `""`) a description of why the event is
+    being nacked
+
+  ## Examples
+
+      # some stream with 3 events
+      stream_name = "my_stream"
+      group_name = "spear_iex"
+      settings = %Spear.PersistentSubscription.Settings{}
+
+      get_event_and_ack = fn conn, sub, action ->
+        receive do
+          %Spear.Event{} = event ->
+            :ok = Spear.nack(conn, sub, event, action: action)
+
+            event
+
+        after
+          3_000 -> :no_events
+        end
+      end
+
+      iex> Spear.create_persistent_subscription(conn, stream_name, group_name, settings)
+      :ok
+      iex> {:ok, sub} = Spear.connect_to_persistent_subscription(conn, self(), stream_name, group_name)
+      iex> get_event_and_nack.(conn, sub, :retry)
+      %Spear.Event{..} # event 0
+      iex> get_event_and_nack.(conn, sub, :retry)
+      %Spear.Event{..} # event 0
+      iex> get_event_and_nack.(conn, sub, :park) # park event 0 and move on
+      %Spear.Event{..} # event 0
+      iex> get_event_and_nack.(conn, sub, :skip) # skip event 1
+      %Spear.Event{..} # event 1
+      iex> get_event_and_nack.(conn, sub, :skip) # skip event 2
+      %Spear.Event{..} # event 2
+      iex> get_event_and_nack.(conn, sub, :skip)
+      :no_events
+      iex> Spear.cancel_subscription(conn, sub)
+      :ok
+  """
+  @doc since: "0.6.0"
+  @doc api: :persistent
+  @spec nack(
+          connection :: Spear.Connection.t(),
+          subscription :: reference(),
+          event_or_ids :: Spear.Event.t() | [String.t()],
+          opts :: Keyword.t()
+        ) :: :ok
+  def nack(conn, subscription, event_or_ids, opts \\ [])
+
+  def nack(conn, sub, %Spear.Event{id: id}, opts), do: nack(conn, sub, [id], opts)
+
+  def nack(conn, sub, event_ids, opts) when is_list(event_ids) do
+    reason = Keyword.get(opts, :reason, "")
+    action = Keyword.get(opts, :action, :retry)
+
+    id = ""
+    ids = Enum.map(event_ids, fn id -> Shared.uuid(value: {:string, id}) end)
+
+    message =
+      Persistent.read_req(
+        content:
+          {:nack,
+           Persistent.read_req_nack(
+             id: id,
+             ids: ids,
+             action: Spear.PersistentSubscription.map_nack_action(action),
+             reason: reason
+           )}
+      )
+
+    Connection.cast(conn, {:push, sub, message})
   end
 end

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -53,7 +53,7 @@ defmodule Spear do
 
       iex> import Spear.Records.Streams, only: [read_resp: 0, read_resp: 1]
       iex> event = Spear.stream!(conn, "my_stream", raw?: true) |> Enum.take(1) |> List.first()
-      {:"event_store.client.streams.ReadResp", {checkpoint, ..}}
+      {:"event_store.client.streams.ReadResp", {:checkpoint, ..}}
       iex> match?(read_resp(), event)
       true
       iex> match?(read_resp(content: {:checkpoint, _}), event)
@@ -1942,7 +1942,9 @@ defmodule Spear do
 
     through =
       if opts[:raw?] do
+        # coveralls-ignore-start
         & &1
+        # coveralls-ignore-stop
       else
         opts[:through]
       end
@@ -2093,7 +2095,9 @@ defmodule Spear do
           event_or_ids :: Spear.Event.t() | [String.t()],
           opts :: Keyword.t()
         ) :: :ok
+  # coveralls-ignore-start
   def nack(conn, subscription, event_or_ids, opts \\ [])
+  # coveralls-ignore-stop
 
   def nack(conn, sub, %Spear.Event{id: id}, opts), do: nack(conn, sub, [id], opts)
 

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -546,7 +546,6 @@ defmodule Spear do
 
     request = opts |> Enum.into(%{}) |> Spear.Reading.build_subscribe_request()
 
-    # YARD deal with broken subscriptions
     Connection.call(conn, {{:subscription, subscriber, through}, request}, opts[:timeout])
   end
 
@@ -1957,7 +1956,6 @@ defmodule Spear do
       }
       |> Spear.Request.expand()
 
-    # YARD deal with broken subscriptions
     Connection.call(conn, {{:subscription, subscriber, through}, request}, opts[:timeout])
   end
 
@@ -2030,7 +2028,6 @@ defmodule Spear do
   def ack(conn, sub, event_ids) when is_list(event_ids) do
     id = ""
     ids = Enum.map(event_ids, fn id -> Shared.uuid(value: {:string, id}) end)
-    # YARD this id field may be incorrect
     message = Persistent.read_req(content: {:ack, Persistent.read_req_ack(id: id, ids: ids)})
 
     Connection.cast(conn, {:push, sub, message})

--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -531,6 +531,55 @@ defmodule Spear.Client do
   @callback list_persistent_subscriptions(opts :: Keyword.t()) ::
               {:ok, Enumerable.t()} | {:error, any()}
 
+  @doc """
+  A wrapper around `Spear.connect_to_persistent_subscription/4`
+  """
+  @doc since: "0.6.0"
+  @callback connect_to_persistent_subscription(
+              subscriber :: pid() | GenServer.name(),
+              stream_name :: String.t(),
+              group_name :: String.t()
+            ) :: {:ok, reference()} | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.connect_to_persistent_subscription/5`
+  """
+  @doc since: "0.6.0"
+  @callback connect_to_persistent_subscription(
+              subscriber :: pid() | GenServer.name(),
+              stream_name :: String.t(),
+              group_name :: String.t(),
+              opts :: Keyword.t()
+            ) :: {:ok, reference()} | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.ack/3`
+  """
+  @doc since: "0.6.0"
+  @callback ack(
+              subscription :: reference(),
+              event_or_ids :: Spear.Event.t() | [String.t()]
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.nack/3`
+  """
+  @doc since: "0.6.0"
+  @callback nack(
+              subscription :: reference(),
+              event_or_ids :: Spear.Event.t() | [String.t()]
+            ) :: :ok | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.nack/4`
+  """
+  @doc since: "0.6.0"
+  @callback nack(
+              subscription :: reference(),
+              event_or_ids :: Spear.Event.t() | [String.t()],
+              opts :: Keyword.t()
+            ) :: :ok | {:error, any()}
+
   @optional_callbacks start_link: 1
 
   defmacro __using__(opts) when is_list(opts) do
@@ -696,6 +745,27 @@ defmodule Spear.Client do
       @impl unquote(__MODULE__)
       def list_persistent_subscriptions(opts \\ []) do
         Spear.list_persistent_subscriptions(__MODULE__, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def connect_to_persistent_subscription(subscriber, stream_name, group_name, opts \\ []) do
+        Spear.connect_to_persistent_subscription(
+          __MODULE__,
+          subscriber,
+          stream_name,
+          group_name,
+          opts
+        )
+      end
+
+      @impl unquote(__MODULE__)
+      def ack(subscription, event_or_ids) do
+        Spear.ack(__MODULE__, subscription, event_or_ids)
+      end
+
+      @impl unquote(__MODULE__)
+      def nack(subscription, event_or_ids, opts \\ []) do
+        Spear.nack(__MODULE__, subscription, event_or_ids, opts)
       end
     end
   end

--- a/lib/spear/connection.ex
+++ b/lib/spear/connection.ex
@@ -211,13 +211,14 @@ defmodule Spear.Connection do
   def handle_cast(:connect, s), do: {:connect, s.config, s}
 
   def handle_cast({:push, request_ref, message}, s) when is_reference(request_ref) do
-    # TODO backpressure and http2 window sizes
+    # YARD backpressure and http2 window sizes
     with %Request{rpc: rpc} <- s.requests[request_ref],
          {wire_data, _size} =
            Spear.Request.to_wire_data(message, rpc.service_module, rpc.request_type),
          {:ok, conn} <- Mint.HTTP2.stream_request_body(s.conn, request_ref, wire_data) do
       {:noreply, put_in(s.conn, conn)}
     else
+      # coveralls-ignore-start
       nil ->
         {:noreply, s}
 
@@ -225,6 +226,7 @@ defmodule Spear.Connection do
         s = put_in(s.conn, conn)
 
         if reason == @closed, do: {:disconnect, :closed, s}, else: {:noreply, s}
+        # coveralls-ignore-stop
     end
   end
 

--- a/lib/spear/connection/request.ex
+++ b/lib/spear/connection/request.ex
@@ -14,9 +14,21 @@ defmodule Spear.Connection.Request do
           type: :request | {:subscription, pid(), (binary -> any())}
         }
 
-  import Spear.Records.Streams, only: [read_resp: 1]
+  alias Spear.Records.{Streams, Persistent}
+  require Streams
+  require Persistent
 
-  defstruct [:continuation, :buffer, :request_ref, :monitor_ref, :from, :response, :status, :type]
+  defstruct [
+    :continuation,
+    :buffer,
+    :request_ref,
+    :monitor_ref,
+    :from,
+    :response,
+    :status,
+    :type,
+    :rpc
+  ]
 
   def new(
         %Spear.Request{messages: event_stream, rpc: %Spear.Rpc{} = rpc},
@@ -42,7 +54,8 @@ defmodule Spear.Connection.Request do
       from: from,
       response: %Spear.Connection.Response{type: {rpc.service_module, rpc.response_type}},
       status: :streaming,
-      type: type
+      type: type,
+      rpc: rpc
     }
   end
 
@@ -108,10 +121,12 @@ defmodule Spear.Connection.Request do
        when finished in [:done, :halted] do
     request = put_in(request.status, :done)
 
+    messages = if request.rpc.request_stream?, do: message_buffer, else: [:eof | message_buffer]
+
     stream_messages(
       put_request(state, request),
       request.request_ref,
-      [:eof | message_buffer]
+      messages
     )
   end
 
@@ -227,7 +242,13 @@ defmodule Spear.Connection.Request do
 
   def handle_data(%__MODULE__{type: {:subscription, subscriber, through}} = request, new_data) do
     case Spear.Grpc.decode_next_message(request.response.data <> new_data, request.response.type) do
-      {read_resp(content: {:confirmation, _confirmation}), rest} ->
+      {Streams.read_resp(content: {:confirmation, _confirmation}), rest} ->
+        GenServer.reply(request.from, {:ok, request.request_ref})
+
+        request = put_in(request.from, nil)
+        put_in(request.response.data, rest)
+
+      {Persistent.read_resp(content: {:subscription_confirmation, _confirmation}), rest} ->
         GenServer.reply(request.from, {:ok, request.request_ref})
 
         request = put_in(request.from, nil)

--- a/lib/spear/connection/request.ex
+++ b/lib/spear/connection/request.ex
@@ -121,7 +121,12 @@ defmodule Spear.Connection.Request do
        when finished in [:done, :halted] do
     request = put_in(request.status, :done)
 
-    messages = if request.rpc.request_stream?, do: message_buffer, else: [:eof | message_buffer]
+    messages =
+      if request.rpc.request_stream? and request.rpc.response_stream? do
+        message_buffer
+      else
+        [:eof | message_buffer]
+      end
 
     stream_messages(
       put_request(state, request),

--- a/lib/spear/event.ex
+++ b/lib/spear/event.ex
@@ -389,6 +389,7 @@ defmodule Spear.Event do
     event
   end
 
+  # coveralls-ignore-start
   defp destructure_read_response(
          Persistent.read_resp(
            content:
@@ -403,6 +404,8 @@ defmodule Spear.Event do
     event
   end
 
+  # coveralls-ignore-stop
+
   defp destructure_read_response(
          Streams.read_resp(
            content:
@@ -416,6 +419,7 @@ defmodule Spear.Event do
     event
   end
 
+  # coveralls-ignore-start
   defp destructure_read_response(
          Persistent.read_resp(
            content:
@@ -428,6 +432,8 @@ defmodule Spear.Event do
        ) do
     event
   end
+
+  # coveralls-ignore-stop
 
   defp destructure_read_response(
          Streams.read_resp(
@@ -442,6 +448,7 @@ defmodule Spear.Event do
     event
   end
 
+  # coveralls-ignore-start
   defp destructure_read_response(
          Persistent.read_resp(
            content:
@@ -454,6 +461,8 @@ defmodule Spear.Event do
        ) do
     event
   end
+
+  # coveralls-ignore-stop
 
   defp record_to_keyword_list(Streams.read_resp_read_event_recorded_event() = event) do
     Streams.read_resp_read_event_recorded_event(event)

--- a/lib/spear/persistent_subscription.ex
+++ b/lib/spear/persistent_subscription.ex
@@ -4,6 +4,34 @@ defmodule Spear.PersistentSubscription do
   """
 
   @typedoc """
+  The action the EventStoreDB should take for an event's nack
+
+  * `:park` - stops the EventStoreDB from re-sending the event and appends a
+    reference to the event to the persistent subscription's parked events
+    stream. These events can be retried later by clicking the "Replay
+    Parked Messages" button in the EventStoreDB dashboard's persistent
+    subscriptions section for each stream+group combination. The EventStoreDB
+    parking system is conceptually similar to dead letter queues.
+  * `:retry` - retries the event up to `:max_retry_count` tries. This option is
+    a reasonable default so that if a consumer hits a transient error condition
+    such as a network timeout, it will retry the event before giving up and
+    parking. Note that once a consumer has retried an event more than
+    `:max_retry_count` times, the event is parked, even if the `:retry` action
+    is given to `Spear.nack/4`.
+  * `:skip` - skips the event without moving it to the parked events stream.
+    Practically this is no different than simply `Spear.ack/3`ing the event(s)
+    and performing a no-op in the consumer. Skipping may be a good option for
+    dealing with poison messages: malformed or otherwise completely
+    unhandleable events.
+  * `:stop` - stops the EventStoreDB from re-sending the event. The event is
+    not parked or retried. It is unclear how this differs from the `:skip`
+    action. This function does not stop the persistent subscription:
+    use `Spear.cancel_subscription/3` to shut down the connection.
+  """
+  @typedoc since: "0.6.0"
+  @type nack_action :: :unknown | :park | :retry | :skip | :stop
+
+  @typedoc """
   A persistent subscription.
 
   These are generally returned from `Spear.list_persistent_subscriptions/2`.
@@ -74,4 +102,11 @@ defmodule Spear.PersistentSubscription do
 
   defp to_atom(string) when is_binary(string), do: String.to_atom(string)
   defp to_atom(_), do: nil
+
+  @doc false
+  def map_nack_action(:park), do: :Park
+  def map_nack_action(:retry), do: :Retry
+  def map_nack_action(:skip), do: :Skip
+  def map_nack_action(:stop), do: :Stop
+  def map_nack_action(_), do: :Unknown
 end


### PR DESCRIPTION
this finishes off the persistent subscriptions API

connects #7 
in conjunction with #23 

was about as complicated as I assumed it'd be: needed to add a bit to Spear.Connection to allow bi-direction streaming

pretty nice to be able to reuse `Spear.cancel_subscription/3` for psubs as well. it works because the cancel mechanism is via [`Mint.HTTP2.cancel_request/2`](https://hexdocs.pm/mint/Mint.HTTP2.html#cancel_request/2) which just sends a GOAWAY frame that tells the server this request is done and don't send any more data on or receive any more data from this request stream