### PR TITLE
send subscribers `{:eos, :dropped}` on stream termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
   that has not yet been created.
     - the reason is a `Spear.Grpc.Response` struct with a status of `:not_found`
 
+### Added
+
+- Subscriptions may now emit `{:eos, :dropped}` in cases where the EventStoreDB
+  explicitly terminates the subscription
+    - this can happen if a persistent subscription is deleted while it has
+      subscribers actively connected
+    - each subscriber will receive `{:eos, :dropped}` in its mailbox
+
 ## 0.6.0 - 2021-04-21
 
 ### Added

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -687,6 +687,22 @@ defmodule SpearTest do
 
       assert reason.status == :not_found
     end
+
+    test "a persistent subscription shows {:eos, :dropped} on deletion", c do
+      settings = %Spear.PersistentSubscription.Settings{}
+      stream = c.stream_name
+      group = uuid_v4()
+      assert Spear.create_persistent_subscription(c.conn, stream, group, settings) == :ok
+
+      assert {:ok, _sub} = Spear.connect_to_persistent_subscription(c.conn, self(), stream, group)
+
+      # empty stream
+      refute_receive %Spear.Event{}
+
+      assert Spear.delete_persistent_subscription(c.conn, stream, group) == :ok
+
+      assert_receive {:eos, :dropped}
+    end
   end
 
   defp random_stream_name do


### PR DESCRIPTION
closes #25 

currently only able to force this condition by deleting a persistent subscription with a subscriber connected, but generally it happens when the server concludes its HTTP2 response to our request (which is what this is written to catch)

:eos already has some prior usage in Spear for subscriptions terminated because the connection is closed/severed (in that case, `{:eos, :closed}`)