### PR TITLE
add subscription references to subscription messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 - 2021-04-24
+
+### Added
+
+- Added the subscription reference returned by `Spear.subscribe/4` and
+  `Spear.connect_to_persistent_subscription/5` to
+    - the metadata map of `t:Spear.Event.t/0` in the path
+      `Spear.Event.metadata.subscription`
+    - `t:Spear.Filter.Checkpoint.t/0` in a new field `:subscription`
+    - the `:eos` tuples in the new shape of
+      `{:eos, reference(), :closed | :dropped}`
+
+Note that this is a breaking change for any consumers matching explicitly
+on `:eos` tuples. Consumers relying on the prior data shape should update
+like so
+
+```diff
+- def handle_info({:eos, reason}, state) do
++ def handle_info({:eos, _subscription, reason}, state) do
+```
+
 ## 0.6.1 - 2021-04-23
 
 ### Fixed

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -127,8 +127,8 @@ defmodule Spear do
     (assuming the chunk read consistently takes `<= 5_000` ms).
   * `:raw?:` - (default: `false`) controls whether or not the enumerable
     `event_stream` is decoded to `Spear.Event` structs from their raw
-    `ReadReq` output. Setting `raw?: true` prevents this transformation and
-    leaves each event as a `ReadReq` record. See
+    `Spear.Records.Streams.read_resp/0` output. Setting `raw?: true` prevents
+    this transformation and leaves each event as a `ReadReq` record. See
     `Spear.Event.from_read_response/2` for more information.
   * `:credentials` - (default: `nil`) a two-tuple `{username, password}` to
     use as credentials for the request. This option overrides any credentials
@@ -252,7 +252,7 @@ defmodule Spear do
   * `:raw?:` - (default: `false`) controls whether or not the enumerable
     `event_stream` is decoded to `Spear.Event` structs from their raw
     `ReadReq` output. Setting `raw?: true` prevents this transformation and
-    leaves each event as a `ReadReq` record. See
+    leaves each event as a `Spear.Records.Streams.read_resp/0` record. See
     `Spear.Event.from_read_response/2` for more information.
   * `:credentials` - (default: `nil`) a two-tuple `{username, password}` to
     use as credentials for the request. This option overrides any credentials
@@ -439,7 +439,11 @@ defmodule Spear do
   ```
 
   or if the `raw?: true` option is provided,
-  `Spear.Records.Streams.read_resp/0` records will be returned.
+  `Spear.Records.Streams.read_resp/0` records will be returned in the shape of
+
+  ```elixir
+  {subscription :: reference(), Spear.Records.Streams.read_resp()}
+  ```
 
   This function will block the caller until the subscription has been
   confirmed by the EventStoreDB.

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -528,7 +528,7 @@ defmodule Spear do
       resolve_links?: true,
       timeout: 5_000,
       raw?: false,
-      through: &Spear.Reading.decode_read_response/1,
+      through: &Spear.Reading.decode_read_response/2,
       credentials: nil
     ]
 
@@ -539,7 +539,7 @@ defmodule Spear do
 
     through =
       if opts[:raw?] do
-        & &1
+        fn resp, subscription -> {subscription, resp} end
       else
         opts[:through]
       end
@@ -1934,7 +1934,7 @@ defmodule Spear do
     default_subscribe_opts = [
       timeout: 5_000,
       raw?: false,
-      through: &Spear.Reading.decode_read_response/1,
+      through: &Spear.Reading.decode_read_response/2,
       credentials: nil,
       buffer_size: 1
     ]
@@ -1959,7 +1959,7 @@ defmodule Spear do
     through =
       if opts[:raw?] do
         # coveralls-ignore-start
-        & &1
+        fn resp, subscription -> {subscription, resp} end
         # coveralls-ignore-stop
       else
         opts[:through]

--- a/lib/spear/connection.ex
+++ b/lib/spear/connection.ex
@@ -396,7 +396,7 @@ defmodule Spear.Connection do
 
     case request do
       %Request{type: {:subscription, subscriber, _through}, from: nil} ->
-        send(subscriber, {:eos, :dropped})
+        send(subscriber, {:eos, request_ref, :dropped})
 
       %Request{from: from, response: response} ->
         Connection.reply(from, {:ok, response})
@@ -436,8 +436,12 @@ defmodule Spear.Connection do
     :ok = s.requests |> Map.values() |> Enum.each(&close_request/1)
   end
 
-  defp close_request(%Request{type: {:subscription, proc, _through}, from: nil}) do
-    send(proc, {:eos, :closed})
+  defp close_request(%Request{
+         type: {:subscription, proc, _through},
+         from: nil,
+         request_ref: request_ref
+       }) do
+    send(proc, {:eos, request_ref, :closed})
   end
 
   defp close_request(%Request{type: _, from: from}) do

--- a/lib/spear/connection/request.ex
+++ b/lib/spear/connection/request.ex
@@ -260,7 +260,7 @@ defmodule Spear.Connection.Request do
         put_in(request.response.data, rest)
 
       {message, rest} ->
-        send(subscriber, through.(message))
+        send(subscriber, through.(message, request.request_ref))
 
         put_in(request.response.data, rest)
 

--- a/lib/spear/event.ex
+++ b/lib/spear/event.ex
@@ -335,15 +335,17 @@ defmodule Spear.Event do
       id: Spear.Uuid.from_proto(uuid),
       type: Map.get(metadata, "type"),
       body: maybe_decoded_body,
-      metadata: %{
-        content_type: content_type,
-        created: Map.get(metadata, "created") |> parse_created_stamp(),
-        prepare_position: prepare_position,
-        commit_position: commit_position,
-        custom_metadata: custom_metadata,
-        stream_name: stream_name,
-        stream_revision: stream_revision
-      }
+      metadata:
+        %{
+          content_type: content_type,
+          created: Map.get(metadata, "created") |> parse_created_stamp(),
+          prepare_position: prepare_position,
+          commit_position: commit_position,
+          custom_metadata: custom_metadata,
+          stream_name: stream_name,
+          stream_revision: stream_revision
+        }
+        |> Map.merge(opts[:metadata] || %{})
     }
   end
 

--- a/lib/spear/reading.ex
+++ b/lib/spear/reading.ex
@@ -15,15 +15,15 @@ defmodule Spear.Reading do
 
   @uuid Streams.read_req_options_uuid_option(content: {:string, empty()})
 
-  def decode_read_response(Streams.read_resp(content: {kind, _body}) = read_resp) do
+  def decode_read_response(Streams.read_resp(content: {kind, _body}) = read_resp, subscription) do
     case kind do
-      :event -> Spear.Event.from_read_response(read_resp)
-      :checkpoint -> Spear.Filter.Checkpoint.from_read_response(read_resp)
+      :event -> Spear.Event.from_read_response(read_resp, metadata: %{subscription: subscription})
+      :checkpoint -> Spear.Filter.Checkpoint.from_read_response(read_resp, subscription)
     end
   end
 
-  def decode_read_response(Persistent.read_resp() = read_resp) do
-    Spear.Event.from_read_response(read_resp)
+  def decode_read_response(Persistent.read_resp() = read_resp, subscription) do
+    Spear.Event.from_read_response(read_resp, metadata: %{subscription: subscription})
   end
 
   def build_read_request(params) do


### PR DESCRIPTION
adds subscription references to all messages emitted by subscriptions

```elixir
{:ok, sub} = Spear.subscribe(conn, .. # or connect_to_persistent_subscription/5
assert_receive %Spear.Event{metadata: %{subscription: ^sub}}
assert_receive %Spear.Filter.Checkpoint{subscription: ^sub}
assert_receive {:eos, ^sub, :closed}
# when `raw?: true` is given as the option
require Spear.Records.Streams, as: Streams
assert_receive {^sub, Streams.read_resp()}
```

closes #29
