### PR TITLE
style: prefer with to case for core functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
       run: mix compile --warnings-as-errors --force
 
     - name: Coveralls
-      run: mix coveralls.github
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: mix coveralls
+      # env:
+        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check formatting
       run: mix format --check-formatted

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "bless": {:hex, :bless, "1.1.0", "b27571e49a4ba22d92412184740b186448a27c3ddf2e9e687851e937932b5a60", [:mix], [], "hexpm", "ea5dc19a36609f927d4035a8409393cd3016b5c482245cffa30b3bd6669c617e"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
-  "castore": {:hex, :castore, "0.1.9", "eb08a94c12ebff92a92d844c6ccd90728dc7662aab9bdc8b3b785ba653c499d5", [:mix], [], "hexpm", "99c3a38ad9c0bab03fee1418c98390da1a31f3b85e317db5840d51a1443d26c8"},
+  "castore": {:hex, :castore, "0.1.10", "b01a007416a0ae4188e70b3b306236021b16c11474038ead7aff79dd75538c23", [:mix], [], "hexpm", "a48314e0cb45682db2ea27b8ebfa11bd6fa0a6e21a65e5772ad83ca136ff2665"},
   "certifi": {:hex, :certifi, "2.6.1", "dbab8e5e155a0763eea978c913ca280a6b544bfa115633fa20249c3d396d9493", [:rebar3], [], "hexpm", "524c97b4991b3849dd5c17a631223896272c6b0af446778ba4675a1dff53bb7e"},
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},
   "credo": {:hex, :credo, "1.5.5", "e8f422026f553bc3bebb81c8e8bf1932f498ca03339856c7fec63d3faac8424b", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "dd8623ab7091956a855dc9f3062486add9c52d310dfd62748779c4315d8247de"},


### PR DESCRIPTION
really cleans up the API

was reading some other project lately and I saw a `with` without an `else` part

I remember seeing that in phoenix projects but I thought that was handled by the `action_fallback/1` thingy and was magic :sparkles: 

but as it turns out it's just totally valid to not have an else block in a with and as the docs say

> If all clauses match, the do block is executed, returning its result. Otherwise
> the chain is aborted and the non-matched value is returned:
>    ```elixir
>    iex> opts = %{width: 10}
>    iex> with {:ok, width} <- Map.fetch(opts, :width),
>    ...>      {:ok, height} <- Map.fetch(opts, :height) do
>    ...>   {:ok, width * height}
>    ...> end
>    :error
>    ```

that makes it perfect for most of the functions in the core API of spear (`lib/spear.ex`) because most of them use this pattern

```elixir
case request/5 do
  {:ok, Api.resp_type(..)} -> :ok
  error -> error
end
```

so that any error from the connection propagates through the `case`

but `with` is perfect for this use-case!