### PR TITLE
store and read link information for reading projected streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
   `Spear.Connection.Configuration`
     - this allows one to limit what the `Spear.Connection` will perform to
       read-only operations such as reading streams
+- Added link metadata to the `Spear.Event.metadata` packet in a new `:link`
+  field
+
+### Fixed
+
+- Fixed the `:from` option in read requests (`Spear.read_stream/3`,
+  `Spear.stream!/3` and `Spear.subscribe/4`) to respect the new link information
+  in metadata
 
 ## 0.7.0 - 2021-04-24
 

--- a/lib/spear/reading.ex
+++ b/lib/spear/reading.ex
@@ -79,6 +79,16 @@ defmodule Spear.Reading do
     |> map_all_position()
   end
 
+  # coveralls-ignore-start
+  defp map_all_position(%Spear.Event{
+         metadata: %{link: %{commit_position: commit, prepare_position: prepare}}
+       }) do
+    {:position,
+     Streams.read_req_options_position(commit_position: commit, prepare_position: prepare)}
+  end
+
+  # coveralls-ignore-stop
+
   defp map_all_position(%Spear.Event{
          metadata: %{commit_position: commit, prepare_position: prepare}
        }) do
@@ -103,6 +113,12 @@ defmodule Spear.Reading do
     |> Spear.Event.from_read_response(link?: true)
     |> map_stream_revision()
   end
+
+  # coveralls-ignore-start
+  defp map_stream_revision(%Spear.Event{metadata: %{link: %{stream_revision: revision}}}),
+    do: {:revision, revision}
+
+  # coveralls-ignore-stop
 
   defp map_stream_revision(%Spear.Event{metadata: %{stream_revision: revision}}),
     do: {:revision, revision}


### PR DESCRIPTION
closes #32 

before this PR on machine:

```elixir
iex> Spear.stream!(conn, "$ce-Spear.Test", chunk_size: 3) |> Enum.take(3)
[
  %Spear.Event{..}, # event 0 in category, 0 in stream
  %Spear.Event{..}, # event 1 in category, 0 in stream
  %Spear.Event{..}  # event 2 in category, 0 in stream
]
iex> event = List.last(v())
%Spear.Event{..} # event 2, 0 in stream
iex> Spear.stream!(conn, "$ce-Spear.Test", chunk_size: 2, from: event) |> Enum.take(2)
[
  %Spear.Event{..}, # event 0 in category, 0 in stream
  %Spear.Event{..}, # event 1 in category, 0 in stream
]
```

Because it would read the `Spear.Event.metadata.revision` field as `0` and think that was the revision of the projected stream.

This PR stores the link information from the read_resp in `Spear.Event.metadata.link` and uses it as the revision/position info for read requests (including subscriptions)
