### PR TITLE
add :link to t:Spear.Event.t/0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 - 2021-04-29
+
+### Added
+
+- Added a `:link` field to the `t:Spear.Event.t/0` struct
+    - this is used to provide accurate stream revisions and IDs in projected
+      streams as with `Spear.subscribe/4` or in `Spear.ack/3` or `Spear.nack/4`
+- Added `Spear.Event.id/1` and `Spear.Event.revision/1` which take a
+  `t:Spear.Event.t/0` and give the ID and revision, respectively
+    - these new functions respect the new `:link` field and return link
+      information instead of event information if the link is present
+
+### Removed
+
+- Removed link metadata from the `Spear.Event.metadata` map's possible `:link`
+  field.
+    - use the new top-level `:link` field as `Spear.Event.link.metadata`
+
+Note that this may be a breaking change for any consumers depending on the
+optional `:link` field in the metadata packet. Consumers should update by
+instead matching on a `t:Spear.Event.t/0` struct in the `:link` field of any
+event, or by using the new `Spear.Event.id/1` or `Spear.Event.revision/1`
+functions.
+
 ## 0.8.1 - 2021-04-27
 
 ### Added

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -1941,13 +1941,13 @@ defmodule Spear do
   gRPC call acknowledges a batch of event IDs.
 
   ```elixir
-  Spear.ack(conn, subscription, events |> Enum.map(& &1.id))
+  Spear.ack(conn, subscription, events |> Enum.map(&Spear.Event.id/1))
   ```
 
   should be preferred over
 
   ```elixir
-  Enum.each(events, &Spear.ack(conn, subscription, &1.id))
+  Enum.each(events, &Spear.ack(conn, subscription, Spear.Event.id(&1)))
   ```
 
   As the acknowledgements will be batched.
@@ -1997,7 +1997,7 @@ defmodule Spear do
         ) :: :ok
   def ack(conn, subscription, event_or_ids)
 
-  def ack(conn, sub, %Spear.Event{id: id}), do: ack(conn, sub, [id])
+  def ack(conn, sub, %Spear.Event{} = event), do: ack(conn, sub, [Spear.Event.id(event)])
 
   def ack(conn, sub, event_ids) when is_list(event_ids) do
     id = ""
@@ -2070,7 +2070,8 @@ defmodule Spear do
   def nack(conn, subscription, event_or_ids, opts \\ [])
   # coveralls-ignore-stop
 
-  def nack(conn, sub, %Spear.Event{id: id}, opts), do: nack(conn, sub, [id], opts)
+  def nack(conn, sub, %Spear.Event{} = event, opts),
+    do: nack(conn, sub, [Spear.Event.id(event)], opts)
 
   def nack(conn, sub, event_ids, opts) when is_list(event_ids) do
     reason = Keyword.get(opts, :reason, "")

--- a/lib/spear/reading.ex
+++ b/lib/spear/reading.ex
@@ -80,11 +80,8 @@ defmodule Spear.Reading do
   end
 
   # coveralls-ignore-start
-  defp map_all_position(%Spear.Event{
-         metadata: %{link: %{commit_position: commit, prepare_position: prepare}}
-       }) do
-    {:position,
-     Streams.read_req_options_position(commit_position: commit, prepare_position: prepare)}
+  defp map_all_position(%Spear.Event{link: %Spear.Event{} = link}) do
+    map_all_position(link)
   end
 
   # coveralls-ignore-stop
@@ -114,14 +111,9 @@ defmodule Spear.Reading do
     |> map_stream_revision()
   end
 
-  # coveralls-ignore-start
-  defp map_stream_revision(%Spear.Event{metadata: %{link: %{stream_revision: revision}}}),
-    do: {:revision, revision}
-
-  # coveralls-ignore-stop
-
-  defp map_stream_revision(%Spear.Event{metadata: %{stream_revision: revision}}),
-    do: {:revision, revision}
+  defp map_stream_revision(%Spear.Event{} = event) do
+    {:revision, Spear.Event.revision(event)}
+  end
 
   defp map_stream_revision(:start), do: {:start, empty()}
   defp map_stream_revision(n) when is_integer(n), do: {:revision, n}

--- a/test/spear/event_test.exs
+++ b/test/spear/event_test.exs
@@ -16,6 +16,16 @@ defmodule Spear.EventTest do
       assert %Spear.Event{id: "5fc66e27-" <> _} =
                Spear.Event.from_read_response(c.event, link?: true)
     end
+
+    test "id/1 returns the link's ID", c do
+      event = c.event |> Spear.Event.from_read_response()
+      assert Spear.Event.id(event) == event.link.id
+    end
+
+    test "revision/1 returns the link's revision", c do
+      event = c.event |> Spear.Event.from_read_response()
+      assert Spear.Event.revision(event) == event.link.metadata.stream_revision
+    end
   end
 
   describe "given a deleted event" do


### PR DESCRIPTION
closes #36 
closes #37 

adds a top-level `:link` field which stores link events in projected streams