### PR TITLE
use a matrix for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Run tests
       if: matrix.beam.elixir != '1.12.2'
-      run: mix test --exclude ${{ matrix.beam.elixir }}:false
+      run: mix test --exclude ${{ matrix.eventstore }}:false
 
     - name: Check formatting
       if: matrix.beam.elixir == '1.12.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         - elixir: "1.12.2"
           otp: "24.0"
         eventstore:
-        - 20.6.0
+        - 20.6.2
         - 21.6.0
     env:
       MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,13 @@ jobs:
       run: mix compile --warnings-as-errors --force
 
     - name: Coveralls
-      if: ${{ matrix.beam.elixir == '1.12.2' && matrix.eventstore == "21.6.0" }}
+      if: ${{ matrix.beam.elixir == '1.12.2' && matrix.eventstore == '21.6.0' }}
       run: mix coveralls.github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run tests
-      if: ${{ matrix.beam.elixir != '1.12.2' && matrix.eventstore != "21.6.0" }}
+      if: ${{ matrix.beam.elixir != '1.12.2' && matrix.eventstore != '21.6.0' }}
       run: mix test --exclude ${{ matrix.eventstore }}:false
 
     - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,13 @@ jobs:
       run: mix compile --warnings-as-errors --force
 
     - name: Coveralls
-      if: matrix.beam.elixir == '1.12.2' and matrix.eventstore == "21.6.0"
+      if: matrix.beam.elixir == '1.12.2' && matrix.eventstore == "21.6.0"
       run: mix coveralls.github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run tests
-      if: matrix.beam.elixir != '1.12.2' and matrix.eventstore != "21.6.0"
+      if: matrix.beam.elixir != '1.12.2' && matrix.eventstore != "21.6.0"
       run: mix test --exclude ${{ matrix.eventstore }}:false
 
     - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,13 @@ jobs:
       run: mix compile --warnings-as-errors --force
 
     - name: Coveralls
-      if: matrix.beam.elixir == '1.12.2' && matrix.eventstore == "21.6.0"
+      if: ${{ matrix.beam.elixir == '1.12.2' && matrix.eventstore == "21.6.0" }}
       run: mix coveralls.github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run tests
-      if: matrix.beam.elixir != '1.12.2' && matrix.eventstore != "21.6.0"
+      if: ${{ matrix.beam.elixir != '1.12.2' && matrix.eventstore != "21.6.0" }}
       run: mix test --exclude ${{ matrix.eventstore }}:false
 
     - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: sed -i 's/21.6.0/${{ matrix.eventstore }}/g' docker-compose.yml
 
     - name: Spawn docker-compose EventStoreDB container
-      run: docker-compose up eventstore --detach
+      run: docker-compose up --detach eventstore
 
     - name: Setup Elixir and Erlang versions
       uses: erlef/setup-beam@v1.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         - elixir: "1.12.2"
           otp: "24.0"
         eventstore:
-        - 20.6.2
+        - 20.6.1
         - 21.6.0
     env:
       MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,13 @@ jobs:
       run: mix compile --warnings-as-errors --force
 
     - name: Coveralls
-      if: matrix.beam.elixir == '1.12.2'
+      if: matrix.beam.elixir == '1.12.2' and matrix.eventstore == "21.6.0"
       run: mix coveralls.github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run tests
-      if: matrix.beam.elixir != '1.12.2'
+      if: matrix.beam.elixir != '1.12.2' and matrix.eventstore != "21.6.0"
       run: mix test --exclude ${{ matrix.eventstore }}:false
 
     - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   bless:
     name: Bless
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
       EVENTSTORE_START_STANDARD_PROJECTIONS: "True"
@@ -79,7 +79,7 @@ jobs:
 
   publish-hex-package:
     name: Publish Hex Package ⬆️☁️
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     env:
       MIX_ENV: dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         env:
           EVENTSTORE_START_STANDARD_PROJECTIONS: True
           EVENTSTORE_RUN_PROJECTIONS: All
+          EVENTSTORE_INSECURE: True
         ports:
         - 2113:2113
-        options: "--insecure"
     env:
       MIX_ENV: test
       EVENTSTORE_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     name: Bless
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         beam:
         - elixir: "1.7.4"
@@ -72,17 +73,17 @@ jobs:
       run: mix compile --warnings-as-errors --force
 
     - name: Coveralls
-      if: matrix.beam.elixir == "1.12.2"
+      if: matrix.beam.elixir == '1.12.2'
       run: mix coveralls.github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run tests
-      if: matrix.beam.elixir != "1.12.2"
+      if: matrix.beam.elixir != '1.12.2'
       run: mix test --exclude ${{ matrix.beam.elixir }}:false
 
     - name: Check formatting
-      if: matrix.beam.elixir == "1.12.2"
+      if: matrix.beam.elixir == '1.12.2'
       run: mix format --check-formatted
 
     - name: Credo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         - elixir: "1.12.2"
           otp: "24.0"
         eventstore:
-        - 20.6.1
+        - 20.10.2
         - 21.6.0
     env:
       MIX_ENV: test
@@ -72,11 +72,17 @@ jobs:
       run: mix compile --warnings-as-errors --force
 
     - name: Coveralls
+      if: matrix.beam.elixir == "1.12.2"
       run: mix coveralls.github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Run tests
+      if: matrix.beam.elixir != "1.12.2"
+      run: mix test --exclude ${{ matrix.beam.elixir }}:false
+
     - name: Check formatting
+      if: matrix.beam.elixir == "1.12.2"
       run: mix format --check-formatted
 
     - name: Credo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,6 @@ jobs:
         eventstore:
         - 20.6.0
         - 21.6.0
-    services:
-      eventstore:
-        image: eventstore/eventstore:${{ matrix.eventstore }}-buster-slim
-        env:
-          EVENTSTORE_START_STANDARD_PROJECTIONS: True
-          EVENTSTORE_RUN_PROJECTIONS: All
-        command: /opt/eventstore/eventstored --insecure --run-projections=All
-        ports:
-        - 2113:2113
     env:
       MIX_ENV: test
       EVENTSTORE_HOST: localhost
@@ -35,6 +26,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Set the EventStoreDB version
+      run: sed -i 's/21.6.0/${{ matrix.eventstore }}/g' docker-compose.yml
+
+    - name: Spawn docker-compose EventStoreDB container
+      run: docker-compose up eventstore --detach
 
     - name: Setup Elixir and Erlang versions
       uses: erlef/setup-beam@v1.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           EVENTSTORE_START_STANDARD_PROJECTIONS: True
           EVENTSTORE_RUN_PROJECTIONS: All
-          EVENTSTORE_INSECURE: True
+        command: /opt/eventstore/eventstored --insecure --run-projections=All
         ports:
         - 2113:2113
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,48 +9,56 @@ jobs:
   bless:
     name: Bless
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        beam:
+        - elixir: "1.7.4"
+          otp: "21.3"
+        - elixir: "1.12.2"
+          otp: "24.0"
+        eventstore:
+        - 20.6.0
+        - 21.6.0
+    services:
+      eventstore:
+        image: eventstore/eventstore:${{ matrix.eventstore }}-buster-slim
+        env:
+          EVENTSTORE_START_STANDARD_PROJECTIONS: True
+          EVENTSTORE_RUN_PROJECTIONS: All
+        ports:
+        - 2113:2113
+        options: "--insecure"
     env:
       MIX_ENV: test
-      EVENTSTORE_START_STANDARD_PROJECTIONS: "True"
-      EVENTSTORE_RUN_PROJECTIONS: All
       EVENTSTORE_HOST: localhost
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Start the EventStoreDB container
-      run: docker-compose up --detach eventstore
-
-    - name: Determine the elixir version
-      run: echo "ELIXIR_VERSION=$(grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}')" >> $GITHUB_ENV
-
-    - name: Determine the otp version
-      run: echo "OTP_VERSION=$(grep -h erlang .tool-versions | awk '{ print $2 }')" >> $GITHUB_ENV
-
     - name: Setup Elixir and Erlang versions
       uses: erlef/setup-beam@v1.7.0
       with:
-        otp-version: ${{ env.OTP_VERSION }}
-        elixir-version: ${{ env.ELIXIR_VERSION }}
+        otp-version: ${{ matrix.beam.otp }}
+        elixir-version: ${{ matrix.beam.elixir }}
 
     - name: Restore the deps cache
       uses: actions/cache@v1
       id: deps-cache
       with:
         path: deps
-        key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+        key: ${{ runner.os }}-${{ matrix.beam.elixir }}-${{ matrix.beam.otp }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-
+          ${{ runner.os }}-${{ matrix.beam.elixir }}-${{ matrix.beam.otp }}-${{ env.MIX_ENV }}-deps-
 
     - name: Restore the _build cache
       uses: actions/cache@v1
       id: build-cache
       with:
         path: _build
-        key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-build-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+        key: ${{ runner.os }}-${{ matrix.beam.elixir  }}-${{ matrix.beam.otp }}-${{ env.MIX_ENV }}-build-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-build-
+          ${{ runner.os }}-${{ matrix.beam.elixir }}-${{ matrix.beam.otp }}-${{ env.MIX_ENV }}-build-
 
     - name: Fetch mix dependencies
       if: steps.deps-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/refresh-dev-cache.yml
+++ b/.github/workflows/refresh-dev-cache.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   refresh-dev-cache:
     name: Refresh Docs Cache
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: dev
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-import_config "#{config_env()}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-import Config
+use Mix.Config
 
 import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-import Config
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,1 @@
-import Config
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-import Config
+use Mix.Config
 
 config :spear, Spear.Test.ClientFixture, connection_string: "esdb://localhost:2113"
 

--- a/test/spear/connection_test.exs
+++ b/test/spear/connection_test.exs
@@ -3,7 +3,7 @@ defmodule Spear.ConnectionTest do
 
   import ExUnit.CaptureLog
 
-  @good_config Application.compile_env!(:spear, :config)
+  @good_config Application.fetch_env!(:spear, :config)
 
   describe "given a connection_string leading nowhere" do
     setup do

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -9,7 +9,7 @@ defmodule SpearTest do
   @max_append_bytes 1_048_576
   @checkpoint_after Integer.pow(32, 3)
 
-  @config Application.compile_env!(:spear, :config)
+  @config Application.fetch_env!(:spear, :config)
 
   setup do
     conn = start_supervised!({Spear.Connection, @config})

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -70,7 +70,7 @@ defmodule SpearTest do
 
       assert ^expected_event_numbers =
                Spear.stream!(c.conn, c.stream_name, direction: :backwards, from: :end)
-               |> then(to_event_numbers)
+               |> to_event_numbers.()
 
       # and with read_stream/3
       assert {:ok, events} =

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -616,6 +616,7 @@ defmodule SpearTest do
       assert Spear.restart_persistent_subscriptions(c.conn) == :ok
     end
 
+    @tag "20.10.2": false
     test "the cluster info shows one active node on localhost", c do
       assert {:ok, [%Spear.ClusterMember{address: "127.0.0.1", alive?: true}]} =
                Spear.cluster_info(c.conn)

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -66,7 +66,7 @@ defmodule SpearTest do
 
     test "a stream may be streamed backwards", c do
       to_event_numbers = fn events -> Stream.map(events, & &1.body) |> Enum.to_list() end
-      expected_event_numbers = Enum.to_list(6..0//-1)
+      expected_event_numbers = Enum.to_list(6..0)
 
       assert ^expected_event_numbers =
                Spear.stream!(c.conn, c.stream_name, direction: :backwards, from: :end)
@@ -92,7 +92,7 @@ defmodule SpearTest do
     test "subscribing at the beginning of a stream emits all of the events", c do
       assert {:ok, sub} = Spear.subscribe(c.conn, self(), c.stream_name, from: :start)
 
-      for n <- 0..6//1 do
+      for n <- 0..6 do
         assert_receive %Spear.Event{body: ^n, metadata: %{subscription: ^sub}}
       end
 
@@ -110,7 +110,7 @@ defmodule SpearTest do
     test "a raw subscription will return ReadResp records", c do
       assert {:ok, sub} = Spear.subscribe(c.conn, self(), c.stream_name, raw?: true)
 
-      for _n <- 0..6//1 do
+      for _n <- 0..6 do
         assert_receive {^sub, read_resp()}
       end
 
@@ -363,7 +363,7 @@ defmodule SpearTest do
       assert_receive %Spear.Event{body: 0} = event, 1_000
       assert %Spear.Filter.Checkpoint{} = Spear.Event.to_checkpoint(event)
 
-      for n <- 1..4//1 do
+      for n <- 1..4 do
         assert_receive %Spear.Event{body: ^n}
       end
 
@@ -376,7 +376,7 @@ defmodule SpearTest do
 
       assert_receive %Spear.Event{body: 0}, 1_000
 
-      for n <- 1..4//1 do
+      for n <- 1..4 do
         assert_receive %Spear.Event{body: ^n}
       end
 

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -7,7 +7,7 @@ defmodule SpearTest do
   import Spear.Uuid, only: [uuid_v4: 0]
 
   @max_append_bytes 1_048_576
-  @checkpoint_after Integer.pow(32, 3)
+  @checkpoint_after 32 * 32 * 32
 
   @config Application.fetch_env!(:spear, :config)
 


### PR DESCRIPTION
closes #44 

runs 4 jobs for CI to ensure that when we update the protos or implement a new feature that the feature should work against the older db version