### PR TITLE
implement new montioring API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run tests
-      if: ${{ matrix.beam.elixir != '1.12.2' && matrix.eventstore != '21.6.0' }}
+      if: ${{ matrix.beam.elixir != '1.12.2' || matrix.eventstore != '21.6.0' }}
       run: mix test --exclude ${{ matrix.eventstore }}:false
 
     - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       MIX_ENV: test
       EVENTSTORE_HOST: localhost
+      EVENTSTORE_VERSION: ${{ matrix.eventstore }}
 
     steps:
     - name: Checkout
@@ -80,7 +81,7 @@ jobs:
 
     - name: Run tests
       if: ${{ matrix.beam.elixir != '1.12.2' || matrix.eventstore != '21.6.0' }}
-      run: mix test --exclude ${{ matrix.eventstore }}:false
+      run: mix test --exclude version_incompatible
 
     - name: Check formatting
       if: matrix.beam.elixir == '1.12.2'

--- a/.iex.exs
+++ b/.iex.exs
@@ -11,7 +11,7 @@ make_server = fn ->
   ]
 
   _insecure_params = [
-    connection_string: "esdb://localhost:2113"
+    connection_string: "esdb://#{host}:2113"
   ]
 
   {:ok, pid} = Spear.Connection.start_link(secure_params)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
     - 'ERL_AFLAGS=-kernel shell_history enabled'
     - EVENTSTORE_HOST=eventstore
+    - EVENTSTORE_VERSION=21.6.0
     volumes:
     - ./:/app
     working_dir: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
     - spear_eventstore:/var/lib/eventstore
     - ./eventstoredb:/etc/eventstore:ro
+    # command: "--insecure --run-projections=All"
     ports:
     - 2113:2113
 

--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -580,6 +580,22 @@ defmodule Spear.Client do
               opts :: Keyword.t()
             ) :: :ok | {:error, any()}
 
+  @doc """
+  A wrapper around `Spear.subscribe_to_stats/3`
+  """
+  @doc since: "0.10.0"
+  @callback subscribe_to_stats(
+              subscriber :: pid() | GenServer.name(),
+              opts :: Keyword.t()
+            ) :: {:ok, reference()} | {:error, any()}
+
+  @doc """
+  A wrapper around `Spear.subscribe_to_stats/2`
+  """
+  @doc since: "0.10.0"
+  @callback subscribe_to_stats(subscriber :: pid() | GenServer.name()) ::
+              {:ok, reference()} | {:error, any()}
+
   @optional_callbacks start_link: 1
 
   defmacro __using__(opts) when is_list(opts) do
@@ -766,6 +782,11 @@ defmodule Spear.Client do
       @impl unquote(__MODULE__)
       def nack(subscription, event_or_ids, opts \\ []) do
         Spear.nack(__MODULE__, subscription, event_or_ids, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def subscribe_to_stats(subscriber, opts \\ []) do
+        Spear.subscribe_to_stats(__MODULE__, subscriber, opts)
       end
     end
   end

--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -581,6 +581,13 @@ defmodule Spear.Client do
             ) :: :ok | {:error, any()}
 
   @doc """
+  A wrapper around `Spear.subscribe_to_stats/2`
+  """
+  @doc since: "0.10.0"
+  @callback subscribe_to_stats(subscriber :: pid() | GenServer.name()) ::
+              {:ok, reference()} | {:error, any()}
+
+  @doc """
   A wrapper around `Spear.subscribe_to_stats/3`
   """
   @doc since: "0.10.0"
@@ -588,13 +595,6 @@ defmodule Spear.Client do
               subscriber :: pid() | GenServer.name(),
               opts :: Keyword.t()
             ) :: {:ok, reference()} | {:error, any()}
-
-  @doc """
-  A wrapper around `Spear.subscribe_to_stats/2`
-  """
-  @doc since: "0.10.0"
-  @callback subscribe_to_stats(subscriber :: pid() | GenServer.name()) ::
-              {:ok, reference()} | {:error, any()}
 
   @optional_callbacks start_link: 1
 

--- a/lib/spear/records/monitoring.ex
+++ b/lib/spear/records/monitoring.ex
@@ -1,0 +1,7 @@
+defmodule Spear.Records.Monitoring do
+  @moduledoc """
+  A record macro interface for interacting with the EventStoreDB Streams API
+  """
+
+  use Spear.Records, service_module: :monitoring
+end

--- a/mix.exs
+++ b/mix.exs
@@ -117,7 +117,8 @@ defmodule Spear.MixProject do
           Spear.Records.Projections,
           Spear.Records.Persistent,
           Spear.Records.Users,
-          Spear.Records.Gossip
+          Spear.Records.Gossip,
+          Spear.Records.Monitoring
         ]
       ],
       groups_for_functions: [
@@ -127,7 +128,8 @@ defmodule Spear.MixProject do
         Operations: &(&1[:api] == :operations),
         Projections: &(&1[:api] == :projections),
         "Persistent Subscriptions": &(&1[:api] == :persistent),
-        Gossip: &(&1[:api] == :gossip)
+        Gossip: &(&1[:api] == :gossip),
+        Gossip: &(&1[:api] == :monitoring)
       ],
       skip_undefined_reference_warnings_on: [
         "CHANGELOG.md"

--- a/mix.exs
+++ b/mix.exs
@@ -129,7 +129,7 @@ defmodule Spear.MixProject do
         Projections: &(&1[:api] == :projections),
         "Persistent Subscriptions": &(&1[:api] == :persistent),
         Gossip: &(&1[:api] == :gossip),
-        Gossip: &(&1[:api] == :monitoring)
+        Monitoring: &(&1[:api] == :monitoring)
       ],
       skip_undefined_reference_warnings_on: [
         "CHANGELOG.md"

--- a/test/fixtures/version_helper.ex
+++ b/test/fixtures/version_helper.ex
@@ -1,0 +1,16 @@
+defmodule VersionHelper do
+  @moduledoc """
+  Provides a function that tags tests depending on their compatibilty with the
+  EventStoreDB version declared in the env
+  """
+
+  @version System.get_env("EVENTSTORE_VERSION")
+
+  def compatible(pattern) do
+    if Version.match?(@version, pattern) do
+      :version_compatible
+    else
+      :version_incompatible
+    end
+  end
+end

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -771,8 +771,8 @@ defmodule SpearTest do
 
     test "a process may subscribe to stats updates with subscribe_to_stats/3", c do
       assert {:ok, subscription} = Spear.subscribe_to_stats(c.conn, self(), interval: 200)
-      assert_receive stats when map_size(stats) >= 500
-      assert_receive stats when map_size(stats) >= 500
+      assert_receive stats when is_map(stats)
+      assert_receive stats when is_map(stats)
       assert Spear.cancel_subscription(c.conn, subscription) == :ok
 
       assert {:ok, subscription} = Spear.subscribe_to_stats(c.conn, self(), raw?: true)

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -768,6 +768,17 @@ defmodule SpearTest do
 
       assert Spear.stream!(c.conn, category, from: :start, chunk_size: 2) |> Enum.count() == 6
     end
+
+    test "a process may subscribe to stats updates with subscribe_to_stats/3", c do
+      assert {:ok, subscription} = Spear.subscribe_to_stats(c.conn, self(), interval: 200)
+      assert_receive stats when map_size(stats) >= 500
+      assert_receive stats when map_size(stats) >= 500
+      assert Spear.cancel_subscription(c.conn, subscription) == :ok
+
+      assert {:ok, subscription} = Spear.subscribe_to_stats(c.conn, self(), raw?: true)
+      assert_receive {^subscription, stats} when is_tuple(stats)
+      assert Spear.cancel_subscription(c.conn, subscription) == :ok
+    end
   end
 
   test "park_stream/2 composes a proper parking stream" do

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -5,6 +5,7 @@ defmodule SpearTest do
 
   import Spear.Records.Streams, only: [read_resp: 0, read_resp: 1]
   import Spear.Uuid, only: [uuid_v4: 0]
+  import VersionHelper
 
   @max_append_bytes 1_048_576
   @checkpoint_after 32 * 32 * 32
@@ -616,7 +617,7 @@ defmodule SpearTest do
       assert Spear.restart_persistent_subscriptions(c.conn) == :ok
     end
 
-    @tag "20.10.2": false
+    @tag compatible("~> 21.0")
     test "the cluster info shows one active node on localhost", c do
       assert {:ok, [%Spear.ClusterMember{address: "127.0.0.1", alive?: true}]} =
                Spear.cluster_info(c.conn)
@@ -769,6 +770,7 @@ defmodule SpearTest do
       assert Spear.stream!(c.conn, category, from: :start, chunk_size: 2) |> Enum.count() == 6
     end
 
+    @tag compatible("~> 21.0")
     test "a process may subscribe to stats updates with subscribe_to_stats/3", c do
       assert {:ok, subscription} = Spear.subscribe_to_stats(c.conn, self(), interval: 200)
       assert_receive stats when is_map(stats)


### PR DESCRIPTION
connects #45 

there's a new feature to get the eventstoredb stats (a map of 502 fields) in the format of a subscription: maps sent to a subscriber process