### PR TITLE
add a helper for declaring test compatibility with ESDB version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       MIX_ENV: test
       EVENTSTORE_HOST: localhost
+      EVENTSTORE_VERSION: ${{ matrix.eventstore }}
 
     steps:
     - name: Checkout
@@ -80,7 +81,7 @@ jobs:
 
     - name: Run tests
       if: ${{ matrix.beam.elixir != '1.12.2' || matrix.eventstore != '21.6.0' }}
-      run: mix test --exclude ${{ matrix.eventstore }}:false
+      run: mix test --exclude version_incompatible
 
     - name: Check formatting
       if: matrix.beam.elixir == '1.12.2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
     - 'ERL_AFLAGS=-kernel shell_history enabled'
     - EVENTSTORE_HOST=eventstore
+    - EVENTSTORE_VERSION=21.6.0
     volumes:
     - ./:/app
     working_dir: /app

--- a/test/fixtures/version_helper.ex
+++ b/test/fixtures/version_helper.ex
@@ -1,0 +1,16 @@
+defmodule VersionHelper do
+  @moduledoc """
+  Provides a macro that tags tests depending on their compatibilty with the
+  EventStoreDB version declared in the env
+  """
+
+  @version System.get_env("EVENTSTORE_VERSION")
+
+  def compatible(pattern) do
+    if Version.match?(@version, pattern) do
+      :version_compatible
+    else
+      :version_incompatible
+    end
+  end
+end

--- a/test/fixtures/version_helper.ex
+++ b/test/fixtures/version_helper.ex
@@ -1,6 +1,6 @@
 defmodule VersionHelper do
   @moduledoc """
-  Provides a macro that tags tests depending on their compatibilty with the
+  Provides a function that tags tests depending on their compatibilty with the
   EventStoreDB version declared in the env
   """
 

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -5,6 +5,7 @@ defmodule SpearTest do
 
   import Spear.Records.Streams, only: [read_resp: 0, read_resp: 1]
   import Spear.Uuid, only: [uuid_v4: 0]
+  import VersionHelper
 
   @max_append_bytes 1_048_576
   @checkpoint_after 32 * 32 * 32
@@ -616,7 +617,7 @@ defmodule SpearTest do
       assert Spear.restart_persistent_subscriptions(c.conn) == :ok
     end
 
-    @tag "20.10.2": false
+    @tag compatible("~> 21.0")
     test "the cluster info shows one active node on localhost", c do
       assert {:ok, [%Spear.ClusterMember{address: "127.0.0.1", alive?: true}]} =
                Spear.cluster_info(c.conn)
@@ -769,6 +770,7 @@ defmodule SpearTest do
       assert Spear.stream!(c.conn, category, from: :start, chunk_size: 2) |> Enum.count() == 6
     end
 
+    @tag compatible("~> 21.0")
     test "a process may subscribe to stats updates with subscribe_to_stats/3", c do
       assert {:ok, subscription} = Spear.subscribe_to_stats(c.conn, self(), interval: 200)
       assert_receive stats when is_map(stats)


### PR DESCRIPTION
as we add newly supported features, we need to write tests that only target that eventstoredb version (or higher version)

this is a little function that looks up a version pattern against the declared eventstoredb version (from the env) and adds a tag that we can use to exclude with `mix test --exclude version_incompatible`