### PR TITLE
implement persistent subscriptions to the :all stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+*Note*: certain Spear versions add support for new EventStoreDB features gated
+behind new EventStoreDB versions. You should not downgrade your Spear version
+in order to avoid these features: Spear aims to keep a stable interface usable
+across all EventStoreDB versions v20+.
+
 ## 0.10.0 - [UNRELEASED]
 
 ### Added
@@ -13,6 +18,17 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Implemented the creation, updating, reading, and deletion of persistent
   subscriptions to the :all stream
     - Note that this feature requires an EventStoreDB v21.6.0 or later
+- Added a dependency on the `:event_store_db_gpb_protobfs` package
+    - this package is just a convenience for developing spear: we can
+      build gpb definitions for the EventStoreDB protobufs on-the-fly
+      via the rebar3 gpb plugin, so we never need to commit the erl/hrl
+      files for the generated gpb modules.
+    - this also allows other (non-Elixir even) libraries to take advantage
+      of versioned, pre-generated gpb definitions for the EventStoreDB
+      grpc interface
+- Added `Spear.subscribe_to_stats/3` and `c:Spear.Client.subscribe_to_stats/2`
+    - this opens a subscription for EventStoreDB monitoring
+    - this feature requires EventStoreDB v21.6.0 or later
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 - [UNRELEASED]
+
+### Added
+
+- Implemented the creation, updating, reading, and deletion of persistent
+  subscriptions to the :all stream
+    - Note that this feature requires an EventStoreDB v21.6.0 or later
+
 ## 0.9.1 - 2021-06-01
 
 ### Added

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -1595,6 +1595,10 @@ defmodule Spear do
 
   See `t:Spear.PersistentSubscription.Settings.t/0` for more information.
 
+  Note that persistent subscriptions to the `:all` stream with server-side
+  filtering is a feature introduced in EventStoreDB v21.6.0. Attempting
+  to use the `:all` stream on older EventStoreDB versions will fail.
+
   ## Options
 
   * `:from` - the position or revision in the stream where the persistent
@@ -1659,6 +1663,10 @@ defmodule Spear do
   Updates an existing persistent subscription
 
   See `t:Spear.PersistentSubscription.Settings.t/0` for more information.
+
+  Note that persistent subscriptions to the `:all` stream with server-side
+  filtering is a feature introduced in EventStoreDB v21.6.0. Attempting
+  to use the `:all` stream on older EventStoreDB versions will fail.
 
   ## Options
 
@@ -1835,6 +1843,10 @@ defmodule Spear do
   Like subscriptions from `subscribe/4`, events can be correlated to their
   subscription by the `:subscription` key in each `Spear.Event.metadata`
   map.
+
+  Note that persistent subscriptions to the `:all` stream with server-side
+  filtering is a feature introduced in EventStoreDB v21.6.0. Attempting
+  to use the `:all` stream on older EventStoreDB versions will fail.
 
   ## Backpressure
 

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -1575,7 +1575,7 @@ defmodule Spear do
   def delete_persistent_subscription(conn, stream_name, group_name, opts \\ [])
 
   def delete_persistent_subscription(conn, stream_name, group_name, opts)
-      when is_binary(stream_name) and is_binary(group_name) do
+      when (is_binary(stream_name) or stream_name == :all) and is_binary(group_name) do
     message =
       Persistent.delete_req(
         options:
@@ -1608,7 +1608,7 @@ defmodule Spear do
   @doc api: :persistent
   @spec create_persistent_subscription(
           connection :: Spear.Connection.t(),
-          stream_name :: String.t(),
+          stream_name :: String.t() | :all,
           group_name :: String.t(),
           settings :: Spear.PersistentSubscription.Settings.t(),
           opts :: Keyword.t()
@@ -1622,7 +1622,7 @@ defmodule Spear do
         %Spear.PersistentSubscription.Settings{} = settings,
         opts
       )
-      when is_binary(stream_name) and is_binary(group_name) do
+      when (is_binary(stream_name) or stream_name == :all) and is_binary(group_name) do
     message =
       Persistent.create_req(
         options:
@@ -1672,7 +1672,7 @@ defmodule Spear do
         %Spear.PersistentSubscription.Settings{} = settings,
         opts
       )
-      when is_binary(stream_name) and is_binary(group_name) do
+      when (is_binary(stream_name) or stream_name == :all) and is_binary(group_name) do
     message =
       Persistent.update_req(
         options:
@@ -1868,14 +1868,14 @@ defmodule Spear do
   @spec connect_to_persistent_subscription(
           connection :: Spear.Connection.t(),
           subscriber :: pid() | GenServer.name(),
-          stream_name :: String.t(),
+          stream_name :: String.t() | :all,
           group_name :: String.t(),
           opts :: Keyword.t()
         ) :: {:ok, subscription :: reference()} | {:error, any()}
   def connect_to_persistent_subscription(conn, subscriber, stream_name, group_name, opts \\ [])
 
   def connect_to_persistent_subscription(conn, subscriber, stream_name, group_name, opts)
-      when is_binary(stream_name) and is_binary(group_name) do
+      when (is_binary(stream_name) or stream_name == :all) and is_binary(group_name) do
     default_subscribe_opts = [
       timeout: 5_000,
       raw?: false,

--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -462,7 +462,7 @@ defmodule Spear.Client do
   """
   @doc since: "0.6.0"
   @callback create_persistent_subscription(
-              stream_name :: String.t(),
+              stream_name :: String.t() | :all,
               group_name :: String.t(),
               settings :: Spear.PersistentSubscription.Settings.t()
             ) :: :ok | {:error, any()}
@@ -472,7 +472,7 @@ defmodule Spear.Client do
   """
   @doc since: "0.6.0"
   @callback create_persistent_subscription(
-              stream_name :: String.t(),
+              stream_name :: String.t() | :all,
               group_name :: String.t(),
               settings :: Spear.PersistentSubscription.Settings.t(),
               opts :: Keyword.t()
@@ -483,7 +483,7 @@ defmodule Spear.Client do
   """
   @doc since: "0.6.0"
   @callback update_persistent_subscription(
-              stream_name :: String.t(),
+              stream_name :: String.t() | :all,
               group_name :: String.t(),
               settings :: Spear.PersistentSubscription.Settings.t()
             ) :: :ok | {:error, any()}
@@ -493,7 +493,7 @@ defmodule Spear.Client do
   """
   @doc since: "0.6.0"
   @callback update_persistent_subscription(
-              stream_name :: String.t(),
+              stream_name :: String.t() | :all,
               group_name :: String.t(),
               settings :: Spear.PersistentSubscription.Settings.t(),
               opts :: Keyword.t()
@@ -504,7 +504,7 @@ defmodule Spear.Client do
   """
   @doc since: "0.6.0"
   @callback delete_persistent_subscription(
-              stream_name :: String.t(),
+              stream_name :: String.t() | :all,
               group_name :: String.t()
             ) :: :ok | {:error, any()}
 
@@ -513,7 +513,7 @@ defmodule Spear.Client do
   """
   @doc since: "0.6.0"
   @callback delete_persistent_subscription(
-              stream_name :: String.t(),
+              stream_name :: String.t() | :all,
               group_name :: String.t(),
               opts :: Keyword.t()
             ) :: :ok | {:error, any()}
@@ -537,7 +537,7 @@ defmodule Spear.Client do
   @doc since: "0.6.0"
   @callback connect_to_persistent_subscription(
               subscriber :: pid() | GenServer.name(),
-              stream_name :: String.t(),
+              stream_name :: String.t() | :all,
               group_name :: String.t()
             ) :: {:ok, reference()} | {:error, any()}
 
@@ -547,7 +547,7 @@ defmodule Spear.Client do
   @doc since: "0.6.0"
   @callback connect_to_persistent_subscription(
               subscriber :: pid() | GenServer.name(),
-              stream_name :: String.t(),
+              stream_name :: String.t() | :all,
               group_name :: String.t(),
               opts :: Keyword.t()
             ) :: {:ok, reference()} | {:error, any()}

--- a/lib/spear/persistent_subscription/settings.ex
+++ b/lib/spear/persistent_subscription/settings.ex
@@ -65,7 +65,7 @@ defmodule Spear.PersistentSubscription.Settings do
   def to_record(%__MODULE__{} = settings, :create) do
     create_req_settings(
       resolve_links: settings.resolve_links?,
-      revision: settings.revision,
+      revision: map_revision(settings.revision),
       extra_statistics: settings.extra_statistics?,
       max_retry_count: settings.max_retry_count,
       min_checkpoint_count: settings.min_checkpoint_count,
@@ -83,7 +83,7 @@ defmodule Spear.PersistentSubscription.Settings do
   def to_record(%__MODULE__{} = settings, :update) do
     update_req_settings(
       resolve_links: settings.resolve_links?,
-      revision: settings.revision,
+      revision: map_revision(settings.revision),
       extra_statistics: settings.extra_statistics?,
       max_retry_count: settings.max_retry_count,
       min_checkpoint_count: settings.min_checkpoint_count,
@@ -106,4 +106,9 @@ defmodule Spear.PersistentSubscription.Settings do
   defp map_checkpoint_after(ms) when is_integer(ms), do: {:checkpoint_after_ms, ms}
 
   # coveralls-ignore-stop
+
+  # this option is deprecated, so it's ok to leave it nil (e.g. when we're
+  # creating a persistent subscription to the :all stream)
+  defp map_revision(revision) when is_integer(revision), do: revision
+  defp map_revision(_), do: nil
 end

--- a/lib/spear/persistent_subscription/settings.ex
+++ b/lib/spear/persistent_subscription/settings.ex
@@ -107,8 +107,8 @@ defmodule Spear.PersistentSubscription.Settings do
 
   # coveralls-ignore-stop
 
-  # this option is deprecated, so it's ok to leave it nil (e.g. when we're
+  # this option is deprecated, so it's ok to leave it undefined (e.g. when we're
   # creating a persistent subscription to the :all stream)
   defp map_revision(revision) when is_integer(revision), do: revision
-  defp map_revision(_), do: nil
+  defp map_revision(_), do: :undefined
 end

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -242,6 +242,7 @@ defmodule SpearTest do
       assert Spear.delete_persistent_subscription(c.conn, c.stream_name, group) == :ok
     end
 
+    @tag compatible("~> 21.6")
     test "a psub to :all works as expected", c do
       group = uuid_v4()
       settings = %Spear.PersistentSubscription.Settings{}

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -270,16 +270,6 @@ defmodule SpearTest do
     end
   end
 
-  defp collect_psub_events(conn, subscription, acc \\ []) do
-    receive do
-      %Spear.Event{} = event ->
-        Spear.ack(conn, subscription, event)
-        collect_psub_events(conn, subscription, [event | acc])
-    after
-      500 -> :lists.reverse(acc)
-    end
-  end
-
   describe "given a subscription to a stream" do
     setup c do
       {:ok, sub} = Spear.subscribe(c.conn, self(), c.stream_name)
@@ -850,5 +840,15 @@ defmodule SpearTest do
       status: :invalid_argument,
       status_code: 3
     }
+  end
+
+  defp collect_psub_events(conn, subscription, acc \\ []) do
+    receive do
+      %Spear.Event{} = event ->
+        Spear.ack(conn, subscription, event)
+        collect_psub_events(conn, subscription, [event | acc])
+    after
+      500 -> :lists.reverse(acc)
+    end
   end
 end


### PR DESCRIPTION
closes #41 
connects #45 

Persistent subscriptions to the `:all` (`$all`) stream were added in EventStoreDB v21.6.0 with some changes to the protobuf definitions. The value of the `:all` stream is that you can define server-side filters when creating the persistent subscription instead of the usual route of building a projected stream and subscribing to that. The server-side filter itself is quite transient - it won't leave a big ole' stream on your EventStoreDB like a projected stream will - and it's said to be quite efficient, even less resource intensive than projections (which we've seen to be a bit expensive at times).

This PR adds support for creating, updating, deleting, and connecting to persistent subscriptions to the :all stream, along with a spot of documentation on how this feature is locked behind an EventStoreDB version.