### PR TITLE
fix $streams metadata stream name for working with ACLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 - [UNRELEASED]
+
+### Fixed
+
+- Fixed the `Spear.set_global_acl/4` function to correctly append ACL
+  data as an event to the `$streams` metadata stream, instead of to
+  the `$streams` stream directly.
+
 ## 0.9.1 - 2021-06-01
 
 ### Added

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -681,7 +681,7 @@ defmodule Spear do
   @doc """
   Sets the global stream ACL
 
-  This function appends an event to the `$streams` EventStoreDB stream
+  This function appends metadata to the `$streams` EventStoreDB stream
   detailing how the EventStoreDB should allow access to user and system
   streams (with the `user_acl` and `system_acl` arguments, respectively).
 
@@ -720,7 +720,7 @@ defmodule Spear do
 
     Spear.Writing.build_global_acl_event(user_acl, system_acl, json_encode!)
     |> List.wrap()
-    |> Spear.append(conn, "$streams", opts)
+    |> Spear.append(conn, "$$$streams", opts)
   end
 
   @doc """


### PR DESCRIPTION
caught this bug looking through the EventStoreDB front-end

The ACL functionality works with metadata, and every stream has a metadata stream which is `$$<stream_name>`, so for `$streams`, it's `$$$streams`. Writing directly to the `$streams` stream appears to have made my local EventStoreDB unhappy, although it didn't fail any tests which is odd :thinking:. This PR changes that function (and documentation) to correctly reflect the metadata stream instead of the actual stream.

Luckily we haven't used this in a production EventStoreDB since Event Store Cloud sets sane permissions on new clusters.