### PR TITLE
add :filter support to stream!/3 and read_stream/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ across all EventStoreDB versions v20+.
 
 - Added the `:include_position?` option to `Spear.read_stream/3` to emit a
   `t:Spear.StreamPosition.t/0` after any events
+- Added the `:filter` option to `Spear.read_stream/3` and `Spear.stream!/3`
+    - This allows one to perform a non-subscription read of the `$all` stream
+      and use a server-side filter
+
+These features are not currently released in EventStoreDB.
 
 ## 0.10.0 - 2021-08-30
 

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -103,6 +103,9 @@ defmodule Spear do
     Reading the EventStoreDB stream forwards will return events in the order
     in which they were written to the EventStoreDB; reading backwards will
     return events in the opposite order.
+  * `:filter` - (default: `nil`) the server-side filter to apply. This option
+    is only valid if the `stream_name` is `:all`. See `Spear.Filter` for more
+    information. This feature requires EventStoreDB vTODO+.
   * `:resolve_links?` - (default: `true`) whether or not to request that
     link references be resolved. See the moduledocs for more information
     about link resolution.
@@ -178,6 +181,7 @@ defmodule Spear do
       from: :start,
       direction: :forwards,
       chunk_size: 128,
+      filter: nil,
       resolve_links?: true,
       through: fn stream -> Stream.map(stream, &Spear.Event.from_read_response/1) end,
       timeout: 5_000,
@@ -226,6 +230,9 @@ defmodule Spear do
     Reading the EventStoreDB stream forwards will return events in the order
     in which they were written to the EventStoreDB; reading backwards will
     return events in the opposite order.
+  * `:filter` - (default: `nil`) the server-side filter to apply. This option
+    is only valid if the `stream_name` is `:all`. See `Spear.Filter` for more
+    information. This feature requires EventStoreDB vTODO+.
   * `:resolve_links?` - (default: `true`) whether or not to request that
     link references be resolved. See the moduledocs for more information
     about link resolution.
@@ -315,6 +322,7 @@ defmodule Spear do
       from: :start,
       direction: :forwards,
       max_count: 42,
+      filter: nil,
       resolve_links?: true,
       through: fn stream ->
         stream |> filter.() |> Stream.map(&Spear.Event.from_read_response/1)

--- a/lib/spear/reading.ex
+++ b/lib/spear/reading.ex
@@ -33,7 +33,7 @@ defmodule Spear.Reading do
           read_direction: map_direction(params.direction),
           resolve_links: params.resolve_links?,
           count_option: {:count, params.max_count},
-          filter_option: map_filter(nil),
+          filter_option: map_filter(params.filter),
           uuid_option: @uuid
         )
     )

--- a/lib/spear/reading/stream.ex
+++ b/lib/spear/reading/stream.ex
@@ -7,6 +7,7 @@ defmodule Spear.Reading.Stream do
     :from,
     :max_count,
     :direction,
+    :filter,
     :resolve_links?,
     :timeout,
     :buffer,

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -101,6 +101,20 @@ defmodule SpearTest do
       assert match?(%Spear.StreamPosition{kind: :all_position}, position)
     end
 
+    @tag compatible(:nightly)
+    test "stream!/3 and read_stream/3 may pass a filter on the :all stream", c do
+      filter = %Spear.Filter{
+        on: :stream_name,
+        by: [c.stream_name],
+        checkpoint_after: @checkpoint_after
+      }
+
+      assert {:ok, events} = Spear.read_stream(c.conn, :all, filter: filter)
+      assert Enum.count(events) == 7
+
+      assert Spear.stream!(c.conn, :all, filter: filter) |> Enum.count() == 7
+    end
+
     test "subscribing at the beginning of a stream emits all of the events", c do
       assert {:ok, sub} = Spear.subscribe(c.conn, self(), c.stream_name, from: :start)
 


### PR DESCRIPTION
requires #55
requires https://github.com/EventStore/EventStore/pull/3133

allows one to pass a server-side filter when doing non-subscription stream reads, like so:

```elixir
iex> Spear.stream!(conn, :all) |> Enum.count
20
iex> Spear.stream!(conn, :all, filter: Spear.Filter.exclude_system_types()) |> Enum.count
0

iex> import Spear.Filter
iex> filter = ~f[$projections-]ps
%Spear.Filter{by: ["$projections-"], checkpoint_after: 1024, on: :stream_name}
iex> Spear.stream!(conn, :all, filter: filter) |> Enum.count
11
iex> Spear.stream!(conn, :all, filter: filter) |> Enum.map(& &1.metadata.stream_name) |> Enum.uniq
["$projections-$all", "$projections-$by_event_type", "$projections-$streams",
 "$projections-$stream_by_category", "$projections-$by_category",
 "$projections-$by_correlation_id"]

iex> forward = Spear.stream!(conn, :all, filter: filter)
iex> backward = Spear.stream!(conn, :all, filter: filter, direction: :backwards, from: :end)
iex> Enum.to_list(forwards) == Enum.reverse(backwards)
true
```

This allows use to properly implement back-pressure to a filtered `:all` subscription in `Volley.InOrderSubscription`.

This feature awaits the next EventStoreDB release.