### PR TITLE
implement BatchAppend RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ across all EventStoreDB versions v20+.
 - Implemented the creation, updating, reading, and deletion of persistent
   subscriptions to the :all stream
     - Note that this feature requires an EventStoreDB v21.6.0 or later
+- Implemented `Spear.append_batch/5` for high-throughput asynchronous appends
 - Added a dependency on the `:event_store_db_gpb_protobfs` package
     - this package is just a convenience for developing spear: we can
       build gpb definitions for the EventStoreDB protobufs on-the-fly

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
     - ./:/app
     working_dir: /app
-    command: tail -f /dev/null
+    command: bash -c "mix local.rebar --force && mix local.hex --force && tail -f /dev/null"
 
 volumes:
   spear_eventstore:

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -412,6 +412,52 @@ defmodule Spear do
   end
 
   @doc """
+  Appends an enumeration of events to an EventStoreDB stream
+
+  ## Options
+
+  * `:expect` - (default: `:any`) the expectation to set on the
+    status of the stream. The write will fail if the expectation fails. See
+    `Spear.ExpectationViolation` for more information about expectations.
+  * `:deadline` - TODO
+  * `:send_ack_to` - (default: `self()`) a process or process name which
+    should receive acknowledgement messages detailing whether a batch has
+    succeded or failed to be committed by the deadline.
+  * `:done?` - (default: false) controls whether this batch of events should
+    close out the entire batch-append request. Attempting to send more batches
+    on the same `batch_id` after a chunk with the `:done?` flag set to `true`
+    will fail.
+  * `:raw?` - (default: `false`) a boolean which controls whether the return
+    signature should TODO
+  * `:credentials` - (default: `nil`) a two-tuple `{username, password}` to
+    use as credentials for the request. This option overrides any credentials
+    set in the connection configuration, if present. See the
+    [Security guide](guides/security.md) for more details.
+
+  ## Examples
+
+      iex> TODO.todo()
+  """
+  @doc since: "0.10.0"
+  @doc api: :streams
+  @spec append_batch(
+          event_stream :: Enumerable.t(),
+          connection :: Spear.Connection.t(),
+          batch_id :: reference() | :new,
+          stream_name :: String.t(),
+          opts :: Keyword.t()
+        ) :: {:ok, batch_id :: reference()} | {:error, term()}
+  def append_batch(event_stream, conn, batch_id, stream_name, opts \\ []) when is_binary(stream_name) and (is_reference(batch_id) or batch_id == :new) do
+    _default_write_opts = [
+      expect: :any,
+      raw?: false,
+      stream: stream_name
+    ]
+
+    # TODO
+  end
+
+  @doc """
   Subscribes a process to an EventStoreDB stream
 
   Unlike `read_stream/3` or `stream!/3`, this function does not return an

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -414,47 +414,166 @@ defmodule Spear do
   @doc """
   Appends an enumeration of events to an EventStoreDB stream
 
+  BatchAppend is a feature added in EventStoreDB version 21.6.0 which aims
+  to optimize append throughput. It works like a persistent subscription
+  in reverse: the client sends chunks of events to write and once the
+  events have been committed, the client receives an acknowledgement
+  message.
+
+  BatchAppends have a life cycle: a new batch append request is created
+  by passing the `:new` atom as the `request_id` argument and a request
+  is concluded by calling `Spear.cancel_subscription/2` on the `request_id`.
+
+  See the [Writing Events](guides/writing_events.md) guide for more information
+  about batching and when to prefer the `append_batch/5` function over
+  `append/4`.
+
+  ## Fragmentation
+
+  By default, each invocation of `append_batch/5` sends a single protobuf
+  message across the wire for all events in the `event_stream` argument.
+  If the `event_stream` argument is very large (> ~1MB), this may be undesirable
+  from a networking perspective.
+
+  The `:done?` flag can be set to `false` to mark a batch as a fragment,
+  which prevents the EventStoreDB from attempting to commit any events
+  sent for the batch until a fragment with the `:done?` flag set
+  to `true` is sent. Each batch of events after the first fragment must
+  pass the initial fragment's `batch_id` in the `:batch_id` option. A
+  set of fragments can be concluded by sending a final `append_batch/5`
+  with the `:done?` option set to `true`.
+
   ## Options
 
+  * `:done?` - (default: `true`) controls whether the current chunk of events
+    being written is complete. See the "Fragmentation" section above for
+    more details.
+  * `:batch_id` - (default: `Spear.Uuid.uuid_v4()`) the unique ID of the
+    batch of events being appended. This must be passed the `batch_id`
+    returned by the first request which sets `:done?` to `false` until
+    a final fragment is appended (`done?: true`). See the "Fragmentation"
+    section above for more details.
   * `:expect` - (default: `:any`) the expectation to set on the
     status of the stream. The write will fail if the expectation fails. See
     `Spear.ExpectationViolation` for more information about expectations.
-  * `:deadline` - TODO
+  * `:deadline` - (default: `nil`) the time the EventStoreDB
+    has to write the batch of events. This can be passed as a `t:DateTime.t/0`
+    or as a tuple of the gregorian seconds `{seconds, nanos}`, or as `nil`
+    which represents that the deadline time is up to the server. If this
+    timestamp comes before the server's current timestamp, the write will
+    time out. If this value exceeds the EventStoreDB's configured write
+    commit timeout, the write commit timeout will be used as the deadline.
   * `:send_ack_to` - (default: `self()`) a process or process name which
     should receive acknowledgement messages detailing whether a batch has
     succeded or failed to be committed by the deadline.
-  * `:done?` - (default: false) controls whether this batch of events should
-    close out the entire batch-append request. Attempting to send more batches
-    on the same `batch_id` after a chunk with the `:done?` flag set to `true`
-    will fail.
-  * `:raw?` - (default: `false`) a boolean which controls whether the return
-    signature should TODO
+  * `:raw?` - (default: `false`) a boolean which controls whether messages
+    emitted to the `:send_ack_to` process are decoded from
+    `Spear.Records.Streams.batch_append_resp/0` records. Spear preserves
+    most of the information when decoding the record into the
+    `t:Spear.BatchAppendResult.t/0` struct, but it discards duplicated
+    information such as stream name and expected revision. Setting
+    the `:raw?` flag allows one to decode the record however they wish.
   * `:credentials` - (default: `nil`) a two-tuple `{username, password}` to
     use as credentials for the request. This option overrides any credentials
     set in the connection configuration, if present. See the
     [Security guide](guides/security.md) for more details.
+  * `:timeout` - (default: `5_000`) the timeout for the initial call to
+    open the batch request>
 
   ## Examples
 
-      iex> TODO.todo()
+      iex> {:ok, first_batch_id, request_id} =
+      ...>   Spear.append_batch(first_batch, conn, :new, first_stream_name)
+      {:ok, "496ba076-098f-4108-a2ca-c73f7b94c06f", #Reference<0.1691282361.2492989441.105913>}
+      iex> receive do
+      ...>   %Spear.BatchAppendResult{request_id: ^request_id, batch_id: ^first_batch_id, result: result} ->
+      ...>     result
+      ...> end
+      :ok
+      iex> {:ok, second_batch_id} =
+      ...>   Spear.append_batch(second_batch, conn, batch_id, second_stream_name)
+      {:ok, "3a1ed972-716c-4679-9cc7-c23c3544e538"}
+      iex> receive(do: (%Spear.BatchAppendResult{request_id: ^request_id, batch_id: ^second_batch_id, result: result}) -> result))
+      :ok
+      iex> {:ok, third_batch_id} =
+      ...>   Spear.append_batch(third_batch, conn, batch_id, third_stream_name)
+      {:ok, "b4eb1330-8c59-48d0-8a0b-2df33672cc0b"}
+      iex> receive(do: (%Spear.BatchAppendResult{request_id: ^request_id, batch_id: ^third_batch_id, result: result}) -> result))
+      :ok
+      iex> Spear.cancel_subscription(conn, request_id)
+      :ok
   """
   @doc since: "0.10.0"
   @doc api: :streams
   @spec append_batch(
           event_stream :: Enumerable.t(),
           connection :: Spear.Connection.t(),
-          batch_id :: reference() | :new,
+          request_id :: reference() | :new,
           stream_name :: String.t(),
           opts :: Keyword.t()
-        ) :: {:ok, batch_id :: reference()} | {:error, term()}
-  def append_batch(event_stream, conn, batch_id, stream_name, opts \\ []) when is_binary(stream_name) and (is_reference(batch_id) or batch_id == :new) do
-    _default_write_opts = [
+        ) ::
+          {:ok, batch_id :: String.t()}
+          | {:ok, batch_id :: String.t(), request_id :: reference()}
+          | {:error, term()}
+  def append_batch(event_stream, conn, request_id, stream_name, opts \\ [])
+      when is_binary(stream_name) and (is_reference(request_id) or request_id == :new) do
+    declared_batch_id = Keyword.get(opts, :batch_id)
+
+    default_write_opts = [
+      explicit_batch_id?: declared_batch_id != nil,
       expect: :any,
+      deadline: nil,
+      done?: true,
       raw?: false,
-      stream: stream_name
+      batch_id: declared_batch_id || Spear.Event.uuid_v4(),
+      timeout: 5_000
     ]
 
-    # TODO
+    opts =
+      default_write_opts
+      |> Keyword.merge(opts)
+      |> Keyword.merge(events: event_stream, stream_name: stream_name)
+
+    message =
+      opts
+      |> Map.new()
+      |> Spear.Writing.build_batch_append_request()
+
+    call_or_cast_batch(conn, message, request_id, opts)
+  end
+
+  # the first batch is a GenServer.call/3 so we can get back the request_id
+  defp call_or_cast_batch(conn, message, :new, opts) do
+    subscriber = Keyword.get(opts, :send_ack_to, self())
+
+    through = &Spear.BatchAppendResult.from_record(&1, &2, opts[:raw?])
+
+    request =
+      %Spear.Request{
+        api: {Streams, :BatchAppend},
+        messages: [message],
+        credentials: opts[:credentials]
+      }
+      |> Spear.Request.expand()
+
+    call = {{:subscription, subscriber, through}, request}
+
+    case Connection.call(conn, call, opts[:timeout]) do
+      {:ok, subscription} when is_reference(subscription) ->
+        {:ok, opts[:batch_id], subscription}
+
+      # coveralls-ignore-start
+      error ->
+        error
+
+        # coveralls-ignore-stop
+    end
+  end
+
+  # subsequent batches are casts: totally async
+  defp call_or_cast_batch(conn, message, request_id, opts) do
+    :ok = Connection.cast(conn, {:push, request_id, message})
+    {:ok, opts[:batch_id]}
   end
 
   @doc """

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -456,13 +456,6 @@ defmodule Spear do
   * `:expect` - (default: `:any`) the expectation to set on the
     status of the stream. The write will fail if the expectation fails. See
     `Spear.ExpectationViolation` for more information about expectations.
-  * `:deadline` - (default: `nil`) the time the EventStoreDB
-    has to write the batch of events. This can be passed as a `t:DateTime.t/0`
-    or as a tuple of the gregorian seconds `{seconds, nanos}`, or as `nil`
-    which represents that the deadline time is up to the server. If this
-    timestamp comes before the server's current timestamp, the write will
-    time out. If this value exceeds the EventStoreDB's configured write
-    commit timeout, the write commit timeout will be used as the deadline.
   * `:send_ack_to` - (default: `self()`) a process or process name which
     should receive acknowledgement messages detailing whether a batch has
     succeded or failed to be committed by the deadline.

--- a/lib/spear/batch_append_result.ex
+++ b/lib/spear/batch_append_result.ex
@@ -1,0 +1,82 @@
+defmodule Spear.BatchAppendResult do
+  @moduledoc """
+  A data structure representing the response to a batch-append request
+
+  This structure is sent to the `:send_ack_to` option when using
+  `Spear.append_batch/5`.
+  """
+  @moduledoc since: "0.10.0"
+
+  require Spear.Records.Streams, as: Streams
+  require Spear.Records.Status, as: Status
+  require Spear.Records.Google, as: Google
+
+  @typedoc """
+  A response to a batch-append request
+
+  When the batch-append succeeds, EventStoreDB returns the current revision
+  and position info in the appended stream. These fields will be `nil` if
+  the append does not succeed.
+  """
+  @typedoc since: "0.10.0"
+  @type t :: %__MODULE__{
+          request_id: reference(),
+          batch_id: String.t(),
+          result: :ok | {:error, %Spear.Grpc.Response{}} | tuple(),
+          revision: non_neg_integer() | :empty | nil,
+          position: Spear.Position.t() | :empty | nil
+        }
+
+  defstruct [:request_id, :batch_id, :result, :revision, :position]
+
+  @doc false
+  def from_record(
+        Streams.batch_append_resp(correlation_id: batch_id, result: result),
+        request_id,
+        raw?
+      ) do
+    %__MODULE__{
+      result: map_result(result, raw?),
+      batch_id: Spear.Uuid.from_proto(batch_id),
+      request_id: request_id,
+      revision: map_revision(result),
+      position: map_position(result)
+    }
+  end
+
+  # coveralls-ignore-start
+  defp map_result(result, true), do: result
+
+  # coveralls-ignore-stop
+
+  defp map_result({:success, Streams.batch_append_resp_success()}, _raw?) do
+    :ok
+  end
+
+  defp map_result({:error, Status.status(code: code, message: message)}, _raw?) do
+    status_code = Spear.Grpc.Response.status_code(code)
+
+    {:error,
+     %Spear.Grpc.Response{
+       status_code: status_code,
+       status: Spear.Grpc.Response.map_status(status_code),
+       message: message
+     }}
+  end
+
+  defp map_revision(
+         {:success, Streams.batch_append_resp_success(current_revision_option: revision)}
+       ),
+       do: map_revision(revision)
+
+  defp map_revision({:current_revision, revision}), do: revision
+  defp map_revision({:empty, Google.empty()}), do: :empty
+  defp map_revision(_), do: nil
+
+  defp map_position({:success, Streams.batch_append_resp_success(position_option: position)}),
+    do: map_position(position)
+
+  defp map_position({:position, position}), do: Spear.Position.from_record(position)
+  defp map_position({:empty, Google.empty()}), do: :empty
+  defp map_position(_), do: nil
+end

--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -77,6 +77,29 @@ defmodule Spear.Client do
               :ok | {:error, any()}
 
   @doc """
+  A wrapper around `Spear.append_batch/4`
+  """
+  @doc since: "0.10.0"
+  @callback append_batch(
+              event_stream :: Enumerable.t(),
+              request_id :: reference() | :new,
+              stream_name :: String.t()
+            ) ::
+              :ok | {:error, any()} | tuple()
+
+  @doc """
+  A wrapper around `Spear.append_batch/5`
+  """
+  @doc since: "0.10.0"
+  @callback append_batch(
+              event_stream :: Enumerable.t(),
+              request_id :: reference() | :new,
+              stream_name :: String.t(),
+              opts :: Keyword.t()
+            ) ::
+              :ok | {:error, any()} | tuple()
+
+  @doc """
   A wrapper around `Spear.cancel_subscription/2`
   """
   @doc since: "0.1.0"
@@ -616,6 +639,11 @@ defmodule Spear.Client do
       @impl unquote(__MODULE__)
       def append(event_stream, stream_name, opts \\ []) do
         Spear.append(event_stream, __MODULE__, stream_name, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def append_batch(event_stream, request_id, stream_name, opts \\ []) do
+        Spear.append_batch(event_stream, __MODULE__, request_id, stream_name, opts)
       end
 
       @impl unquote(__MODULE__)

--- a/lib/spear/grpc/response.ex
+++ b/lib/spear/grpc/response.ex
@@ -30,6 +30,12 @@ defmodule Grpc.Response do
     15 => :data_loss,
     16 => :unauthenticated
   }
+  @reverse_capitalized_status_code_mapping Map.new(@status_code_mapping, fn {status_code, status} ->
+                                             {status
+                                              |> Atom.to_string()
+                                              |> String.upcase()
+                                              |> String.to_atom(), status_code}
+                                           end)
 
   def from_connection_response(%Response{status: status}, _request, _raw?) when status != 200 do
     %__MODULE__{
@@ -104,4 +110,10 @@ defmodule Grpc.Response do
   end
 
   def map_status(_), do: :unknown
+
+  for {status, code} <- @reverse_capitalized_status_code_mapping do
+    def status_code(unquote(status)), do: unquote(code)
+  end
+
+  def status_code(_), do: 2
 end

--- a/lib/spear/position.ex
+++ b/lib/spear/position.ex
@@ -2,6 +2,7 @@ defmodule Spear.Position do
   @moduledoc """
   A data structure representing a position in the `$all` stream
   """
+  @moduledoc since: "0.10.0"
 
   require Spear.Records.Shared, as: Shared
 
@@ -9,6 +10,7 @@ defmodule Spear.Position do
   A struct representing the prepare and commit positions for an event in the
   `$all` stream
   """
+  @typedoc since: "0.10.0"
   @type t :: %__MODULE__{commit: integer(), prepare: integer()}
 
   defstruct [:commit, :prepare]

--- a/lib/spear/position.ex
+++ b/lib/spear/position.ex
@@ -1,0 +1,20 @@
+defmodule Spear.Position do
+  @moduledoc """
+  A data structure representing a position in the `$all` stream
+  """
+
+  require Spear.Records.Shared, as: Shared
+
+  @typedoc """
+  A struct representing the prepare and commit positions for an event in the
+  `$all` stream
+  """
+  @type t :: %__MODULE__{commit: integer(), prepare: integer()}
+
+  defstruct [:commit, :prepare]
+
+  @doc false
+  def from_record(Shared.all_stream_position(commit_position: commit, prepare_position: prepare)) do
+    %__MODULE__{commit: commit, prepare: prepare}
+  end
+end

--- a/lib/spear/records/google.ex
+++ b/lib/spear/records/google.ex
@@ -1,0 +1,22 @@
+defmodule Spear.Records.Google do
+  @moduledoc """
+  A record-like wrapper around google protobufs
+  """
+
+  defmacro empty do
+    quote do
+      {:"google.protobuf.Empty"}
+    end
+  end
+
+  def timestamp(%DateTime{} = datetime) do
+    # google timestamp is number of seconds from the first second of 1970 (smeared)
+    update_in(datetime.year, &(&1 - 1970))
+    |> DateTime.to_gregorian_seconds()
+    |> timestamp()
+  end
+
+  def timestamp({seconds, nanos}) do
+    {:"google.protobuf.Timestamp", seconds, nanos}
+  end
+end

--- a/lib/spear/records/google.ex
+++ b/lib/spear/records/google.ex
@@ -9,11 +9,13 @@ defmodule Spear.Records.Google do
     end
   end
 
-  def timestamp(%DateTime{} = datetime) do
-    # google timestamp is number of seconds from the first second of 1970 (smeared)
-    update_in(datetime.year, &(&1 - 1970))
-    |> DateTime.to_gregorian_seconds()
-    |> timestamp()
+  if Version.match?(System.version(), ">= 1.11.0") do
+    def timestamp(%DateTime{} = datetime) do
+      # google timestamp is number of seconds from the first second of 1970 (smeared)
+      update_in(datetime.year, &(&1 - 1970))
+      |> DateTime.to_gregorian_seconds()
+      |> timestamp()
+    end
   end
 
   def timestamp({seconds, nanos}) do

--- a/lib/spear/records/status.ex
+++ b/lib/spear/records/status.ex
@@ -1,0 +1,8 @@
+defmodule Spear.Records.Status do
+  @moduledoc """
+  A record macro interface for interacting with the google.rpc.Status type
+  used in the protos
+  """
+
+  use Spear.Records, service_module: :status
+end

--- a/lib/spear/writing.ex
+++ b/lib/spear/writing.ex
@@ -12,14 +12,20 @@ defmodule Spear.Writing do
       delete_req: 1,
       delete_req_options: 1,
       tombstone_req: 1,
-      tombstone_req_options: 1
+      tombstone_req_options: 1,
+      batch_append_req: 1,
+      batch_append_req_options: 1,
+      batch_append_req_proposed_message: 0
     ]
 
   import Spear.Records.Shared,
     only: [
       stream_identifier: 1,
-      empty: 0
+      empty: 0,
+      uuid: 1
     ]
+
+  require Spear.Records.Google, as: Google
 
   alias Spear.ExpectationViolation
 
@@ -51,6 +57,15 @@ defmodule Spear.Writing do
           stream_identifier: stream_identifier(stream_name: params.stream),
           expected_stream_revision: map_expectation(params.expect)
         )
+    )
+  end
+
+  def build_batch_append_request(params) do
+    batch_append_req(
+      correlation_id: uuid(value: {:string, params.batch_id}),
+      options: map_batch_append_options(params),
+      proposed_messages: Enum.map(params.events, &map_batch_append_messages/1),
+      is_final: params.done?
     )
   end
 
@@ -102,6 +117,43 @@ defmodule Spear.Writing do
       }
       |> json_encode!.(),
       content_type: "application/vnd.eventstore.events+json"
+    )
+  end
+
+  defp map_batch_append_options(%{continuation?: true}), do: :undefined
+
+  defp map_batch_append_options(params) do
+    batch_append_req_options(
+      stream_identifier: stream_identifier(stream_name: params.stream_name),
+      expected_stream_position: map_expected_position(params.expect),
+      deadline: map_deadline(params.deadline)
+    )
+  end
+
+  defp map_deadline(nil), do: :undefined
+  # coveralls-ignore-start
+  defp map_deadline(deadline), do: Google.timestamp(deadline)
+  # coveralls-ignore-stop
+
+  defp map_expected_position(revision) when is_integer(revision) and revision >= 1,
+    do: {:stream_position, revision}
+
+  defp map_expected_position(:empty), do: {:no_stream, Google.empty()}
+  defp map_expected_position(:exists), do: {:stream_exists, Google.empty()}
+  defp map_expected_position(:any), do: {:any, Google.empty()}
+
+  # coveralls-ignore-start
+  defp map_batch_append_messages(batch_append_req_proposed_message() = message) do
+    message
+  end
+
+  # coveralls-ignore-stop
+
+  defp map_batch_append_messages(%Spear.Event{} = event) do
+    Spear.Event.to_proposed_message(
+      event,
+      %{"application/json" => &Jason.encode!/1},
+      :batch_append
     )
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -108,7 +108,9 @@ defmodule Spear.MixProject do
           Spear.ClusterMember,
           Spear.Scavenge,
           Spear.PersistentSubscription,
-          Spear.PersistentSubscription.Settings
+          Spear.PersistentSubscription.Settings,
+          Spear.Position,
+          Spear.BatchAppendResult
         ],
         "Record interfaces": [
           Spear.Records.Shared,
@@ -118,7 +120,9 @@ defmodule Spear.MixProject do
           Spear.Records.Persistent,
           Spear.Records.Users,
           Spear.Records.Gossip,
-          Spear.Records.Monitoring
+          Spear.Records.Monitoring,
+          Spear.Records.Google,
+          Spear.Records.Status
         ]
       ],
       groups_for_functions: [


### PR DESCRIPTION
closes #53 
closes #45 

BatchAppend is a new RPC in the Streams API that was added in v21.6.0. It's a bi-directional append: the client emits chunks to the server to commit and the server sends back acknowledgements when it's done.

The real-world application I see for this is for the [replicator](https://replicator.eventstore.org/) ("shovel" as we call our internal version): it should work nicely to really push the append throughput, especially since you can commit batches of events belonging to different streams.

This ended up being much more work than I thought that it would be because of how intricate the behavior is: it supports framentation by configuring `Spear.append_batch/5` with the options `done?: false` and passing old `:batch_id`s. See the tests for some examples.

For the life of me I can't figure out what the `:deadline` option actually does, even when attempting to read through the EventStoreDB [implementation](https://github.com/EventStore/EventStore/blob/08633f0b1a42083dd7a5d7df711e1ed66597e7c4/src/EventStore.Core/Services/Transport/Grpc/Streams.BatchAppend.cs#L261-L270) of the BatchAppend handler. I may have to poke around to see if it's just my understanding or a bug