### PR TITLE
guard against non-event ReadResps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ across all EventStoreDB versions v20+.
     - this opens a subscription for EventStoreDB monitoring
     - this feature requires EventStoreDB v21.6.0 or later
 
+### Changed
+
+- Non-event read responses are now discarded when reading from a stream
+    - this will allow the compatibility of spear v0.10.0 with the next
+      release of EventStoreDB
+    - this should not change behavior with any existing EventStoreDB
+      versions
+
 ### Fixed
 
 - Fixed the `Spear.set_global_acl/4` function to correctly append ACL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   eventstore:
-    image: ghcr.io/eventstore/eventstore/eventstore:21.2.1-alpha.0.160-buster-slim
+    image: eventstore/eventstore:21.6.0-buster-slim
     environment:
     - EVENTSTORE_START_STANDARD_PROJECTIONS=True
     - EVENTSTORE_RUN_PROJECTIONS=All

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   eventstore:
-    image: eventstore/eventstore:21.6.0-buster-slim
+    image: ghcr.io/eventstore/eventstore/eventstore:21.2.1-alpha.0.160-buster-slim
     environment:
     - EVENTSTORE_START_STANDARD_PROJECTIONS=True
     - EVENTSTORE_RUN_PROJECTIONS=All

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -306,7 +306,11 @@ defmodule Spear do
       direction: :forwards,
       max_count: 42,
       resolve_links?: true,
-      through: fn stream -> Stream.map(stream, &Spear.Event.from_read_response/1) end,
+      through: fn stream ->
+        stream
+        |> Stream.filter(&Spear.Event.event?/1)
+        |> Stream.map(&Spear.Event.from_read_response/1)
+      end,
       timeout: 5_000,
       raw?: false,
       credentials: nil

--- a/lib/spear/event.ex
+++ b/lib/spear/event.ex
@@ -641,4 +641,9 @@ defmodule Spear.Event do
   @spec id(t()) :: String.t()
   def id(%__MODULE__{link: %__MODULE__{} = link}), do: id(link)
   def id(%__MODULE__{id: id}), do: id
+
+  @doc false
+  def event?(Streams.read_resp(content: {:event, _event})), do: true
+  def event?(%__MODULE__{}), do: true
+  def event?(_), do: false
 end


### PR DESCRIPTION
closes #54 

Adds some guards against the content-type of the ReadResp message to ensure that we don't try to give anything to the library user that can't be decoded.

With the current version of the protobufs (via `event_store_db_gpb_protobufs`), we decode the trailing stream position messages as:

```elixir
{:"event_store.client.streams.ReadResp", :undefined}
```

which fails some pattern matches / function clauses. This pr sets up the necessary function clauses to only allow ReadResps through when they contain events.