### PR TITLE
add append_batch_stream/2 helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,18 @@ behind new EventStoreDB versions. You should not downgrade your Spear version
 in order to avoid these features: Spear aims to keep a stable interface usable
 across all EventStoreDB versions v20+.
 
-## 0.10.0 - [UNRELEASED]
+## 0.10.0 - 2021-08-30
 
 ### Added
 
 - Implemented the creation, updating, reading, and deletion of persistent
-  subscriptions to the :all stream
-    - Note that this feature requires an EventStoreDB v21.6.0 or later
+  subscriptions to the `:all` stream
+    - this feature requires EventStoreDB v21.6.0 or later
 - Implemented `Spear.append_batch/5` for high-throughput asynchronous appends
+    - this feature requires EventStoreDB v21.6.0 or later
+- Added `Spear.subscribe_to_stats/3` and `c:Spear.Client.subscribe_to_stats/2`
+    - this opens a subscription for EventStoreDB monitoring
+    - this feature requires EventStoreDB v21.6.0 or later
 - Added a dependency on the `:event_store_db_gpb_protobfs` package
     - this package is just a convenience for developing spear: we can
       build gpb definitions for the EventStoreDB protobufs on-the-fly
@@ -27,9 +31,6 @@ across all EventStoreDB versions v20+.
     - this also allows other (non-Elixir even) libraries to take advantage
       of versioned, pre-generated gpb definitions for the EventStoreDB
       grpc interface
-- Added `Spear.subscribe_to_stats/3` and `c:Spear.Client.subscribe_to_stats/2`
-    - this opens a subscription for EventStoreDB monitoring
-    - this feature requires EventStoreDB v21.6.0 or later
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ across all EventStoreDB versions v20+.
     - this feature requires EventStoreDB v21.6.0 or later
 - Implemented `Spear.append_batch/5` for high-throughput asynchronous appends
     - this feature requires EventStoreDB v21.6.0 or later
+    - `Spear.append_batch_stream/2` has also been added for convenience
 - Added `Spear.subscribe_to_stats/3` and `c:Spear.Client.subscribe_to_stats/2`
     - this opens a subscription for EventStoreDB monitoring
     - this feature requires EventStoreDB v21.6.0 or later

--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -100,6 +100,12 @@ defmodule Spear.Client do
               :ok | {:error, any()} | tuple()
 
   @doc """
+  A wrapper around `Spear.append_batch_stream/2`
+  """
+  @doc since: "0.10.0"
+  @callback append_batch_stream(batch_stream :: Enumerable.t()) :: Enumerable.t()
+
+  @doc """
   A wrapper around `Spear.cancel_subscription/2`
   """
   @doc since: "0.1.0"
@@ -644,6 +650,11 @@ defmodule Spear.Client do
       @impl unquote(__MODULE__)
       def append_batch(event_stream, request_id, stream_name, opts \\ []) do
         Spear.append_batch(event_stream, __MODULE__, request_id, stream_name, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def append_batch_stream(batch_stream) do
+        Spear.append_batch_stream(batch_stream, __MODULE__)
       end
 
       @impl unquote(__MODULE__)


### PR DESCRIPTION
bit of a refactor of the return value of `Spear.append_batch/5`

adds a helper that wraps a stream of batches with the necessary life-cycle hooks that append_batch/5 needs so it's easier to use

see the test case for a nice example invocation