### PR TITLE
add nightly EventStore build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
         - elixir: "1.12.2"
           otp: "24.0"
         eventstore:
-        - 20.10.2
-        - 21.6.0
+        - "eventstore/eventstore:20.10.2-buster-slim"
+        - "eventstore/eventstore:21.6.0-buster-slim"
+        - "ghcr.io/eventstore/eventstore:ci"
     env:
       MIX_ENV: test
       EVENTSTORE_HOST: localhost
@@ -30,7 +31,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set the EventStoreDB version
-      run: sed -i 's/21.6.0/${{ matrix.eventstore }}/g' docker-compose.yml
+      run: sed -i 's/eventstore\/eventstore:21\.6\.0-buster-slim/${{ matrix.eventstore }}/g' docker-compose.yml
 
     - name: Spawn docker-compose EventStoreDB container
       run: docker-compose up --detach eventstore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set the EventStoreDB version
-      run: sed -i 's/eventstore\/eventstore:21\.6\.0-buster-slim/${{ matrix.eventstore }}/g' docker-compose.yml
+      run: sed -i 's|eventstore/eventstore:21.6.0-buster-slim|${{ matrix.eventstore }}|g' docker-compose.yml
 
     - name: Spawn docker-compose EventStoreDB container
       run: docker-compose up --detach eventstore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         beam:
         - elixir: "1.7.4"
           otp: "21.3"
-        - elixir: "1.12.2"
+        - elixir: "1.12.3"
           otp: "24.0"
         eventstore:
         - "eventstore/eventstore:20.10.2-buster-slim"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,24 +3,30 @@ version: '3.8'
 services:
   eventstore:
     image: eventstore/eventstore:21.6.0-buster-slim
+    # switch to nightly:
+    # image: ghcr.io/eventstore/eventstore:ci
     environment:
     - EVENTSTORE_START_STANDARD_PROJECTIONS=True
     - EVENTSTORE_RUN_PROJECTIONS=All
     volumes:
     - spear_eventstore:/var/lib/eventstore
     - ./eventstoredb:/etc/eventstore:ro
+    # to run in insecure mode, which can be nice for debugging protobuf
+    # messages via wireshark
     # command: "--insecure --run-projections=All"
     ports:
     - 2113:2113
 
   app:
-    image: elixir:1.12.1
+    image: elixir:1.12.3
     depends_on:
     - eventstore
     environment:
     - 'ERL_AFLAGS=-kernel shell_history enabled'
     - EVENTSTORE_HOST=eventstore
     - EVENTSTORE_VERSION=21.6.0
+    # switch to nightly:
+    # - EVENTSTORE_VERSION=nightly
     volumes:
     - ./:/app
     working_dir: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     - 2113:2113
 
   app:
-    image: elixir:1.12.3
+    image: elixir:1.12.2
     depends_on:
     - eventstore
     environment:

--- a/lib/spear/reading/stream.ex
+++ b/lib/spear/reading/stream.ex
@@ -108,8 +108,11 @@ defmodule Spear.Reading.Stream do
         {message, %__MODULE__{state | buffer: remaining_buffer, from: message}}
 
       # skip non-event read responses
+      # coveralls-ignore-start
       {Streams.read_resp(), remaining_buffer} ->
         unfold_continuous(%__MODULE__{state | buffer: remaining_buffer})
+
+      # coveralls-ignore-stop
 
       _ ->
         nil

--- a/test/fixtures/version_helper.ex
+++ b/test/fixtures/version_helper.ex
@@ -25,23 +25,20 @@ defmodule VersionHelper do
 
   @version version
 
-  def compatible(pattern) do
-    # we get some "warning: this check/guard will always yield the same result"s
-    # on old elixir versions if we don't do this because the compiler is too
-    # smart for its own good :P
-    version = @version
+  defp version, do: @version
 
+  def compatible(pattern) do
     cond do
-      pattern == :nightly and version == :nightly ->
+      pattern == :nightly and version() == :nightly ->
         :version_compatible
 
       not is_binary(pattern) ->
         :version_incompatible
 
-      version == :nightly ->
+      version() == :nightly ->
         :version_compatible
 
-      Version.match?(version, pattern) ->
+      Version.match?(version(), pattern) ->
         :version_compatible
 
       true ->

--- a/test/fixtures/version_helper.ex
+++ b/test/fixtures/version_helper.ex
@@ -26,17 +26,22 @@ defmodule VersionHelper do
   @version version
 
   def compatible(pattern) do
+    # we get some "warning: this check/guard will always yield the same result"s
+    # on old elixir versions if we don't do this because the compiler is too
+    # smart for its own good :P
+    version = @version
+
     cond do
-      pattern == :nightly and @version == :nightly ->
+      pattern == :nightly and version == :nightly ->
         :version_compatible
 
       not is_binary(pattern) ->
         :version_incompatible
 
-      @version == :nightly ->
+      version == :nightly ->
         :version_compatible
 
-      Version.match?(@version, pattern) ->
+      Version.match?(version, pattern) ->
         :version_compatible
 
       true ->

--- a/test/fixtures/version_helper.ex
+++ b/test/fixtures/version_helper.ex
@@ -30,6 +30,12 @@ defmodule VersionHelper do
       pattern == :nightly and @version == :nightly ->
         :version_compatible
 
+      not is_binary(pattern) ->
+        :version_incompatible
+
+      @version == :nightly ->
+        :version_compatible
+
       Version.match?(@version, pattern) ->
         :version_compatible
 

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -927,7 +927,7 @@ defmodule SpearTest do
       assert {:ok, batch_id, request_id} =
                random_events()
                |> Stream.take(5)
-               |> Spear.append_batch(c.conn, :new, c.stream_name, deadline: deadline, done?: true)
+               |> Spear.append_batch(c.conn, :new, c.stream_name, deadline: deadline)
 
       assert_receive %Spear.BatchAppendResult{
         result: {:error, %Spear.Grpc.Response{message: "Timeout", status: :deadline_exceeded}},

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -919,7 +919,6 @@ defmodule SpearTest do
       assert Spear.stream!(c.conn, c.stream_name) |> Enum.to_list() == []
     end
 
-    # fixed https://github.com/EventStore/EventStore/pull/3138
     @tag compatible(:nightly)
     test "append_batch/5 with a deadline in the past will fail", c do
       _deadline = DateTime.utc_now() |> DateTime.add(-(60 * 3600), :second)

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -921,8 +921,7 @@ defmodule SpearTest do
 
     @tag compatible(:nightly)
     test "append_batch/5 with a deadline in the past will fail", c do
-      _deadline = DateTime.utc_now() |> DateTime.add(-(60 * 3600), :second)
-      deadline = {0, 0}
+      deadline = Map.update!(DateTime.utc_now(), :second, &(&1 - 1))
 
       assert {:ok, batch_id, request_id} =
                random_events()

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -921,7 +921,7 @@ defmodule SpearTest do
 
     @tag compatible(:nightly)
     test "append_batch/5 with a deadline in the past will fail", c do
-      deadline = Map.update!(DateTime.utc_now(), :second, &(&1 - 1))
+      deadline = {0, 0}
 
       assert {:ok, batch_id, request_id} =
                random_events()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,7 @@
 ExUnit.configure(
   assert_receive_timeout: 1_000,
   refute_receive_timeout: 300,
-  exclude: [:operations, :flaky]
+  exclude: [:operations, :flaky, :version_incompatible]
 )
 
 ExUnit.start()


### PR DESCRIPTION
connects #60

adds the image that the eventstore team publishes nightly to the CI matrix

useful for sniffing out new protobuf breakages and testing features not yet released

this also allows us to enable some tests for upcoming unreleased features. one of those tests is now enabled with

```elixir
@tag compatible(:nightly)
```