### PR TITLE
Fix typos

### DIFF
--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -471,7 +471,7 @@ defmodule Spear do
     `Spear.ExpectationViolation` for more information about expectations.
   * `:send_ack_to` - (default: `self()`) a process or process name which
     should receive acknowledgement messages detailing whether a batch has
-    succeded or failed to be committed by the deadline.
+    succeeded or failed to be committed by the deadline.
   * `:raw?` - (default: `false`) a boolean which controls whether messages
     emitted to the `:send_ack_to` process are decoded from
     `Spear.Records.Streams.batch_append_resp/0` records. Spear preserves
@@ -887,7 +887,7 @@ defmodule Spear do
   * `:timeout` - (default: `5_000` - 5s) the time allowed to block while
     waiting for the EventStoreDB to delete the stream.
   * `:expect` - (default: `:any`) the expected state of the stream when
-    performing the deleteion. See `append/4` and `Spear.ExpectationViolation`
+    performing the deletion. See `append/4` and `Spear.ExpectationViolation`
     for more information.
   * `:credentials` - (default: `nil`) a two-tuple `{username, password}` to
     use as credentials for the request. This option overrides any credentials
@@ -1876,7 +1876,7 @@ defmodule Spear do
   * `:from` - the position or revision in the stream where the persistent
     subscription should start. This option may be `:start` or `:end`
     describing the beginning or end of the stream. When the `stream_name`
-    is `:all`, this paramater describes the prepare and commit positions
+    is `:all`, this parameter describes the prepare and commit positions
     in the `:all` stream which can be found on any event emitted from a
     subscription to the `:all` stream. When the `stream_name` is not the
     `:all` stream, this option may be an integer representing the event
@@ -2096,7 +2096,7 @@ defmodule Spear do
   has explicitly told the subscriber that the subscription is terminated.
   This can occur for persistent subscriptions in the case where the
   subscription is deleted (e.g. via `Spear.delete_persistent_subscription/4`).
-  `subscription` is the reference retuned by this function.
+  `subscription` is the reference returned by this function.
 
   ```elixir
   iex> Spear.create_persistent_subscription(conn, "asdf", "asdf", %Spear.PersistentSubscription.Settings{})

--- a/lib/spear/acl.ex
+++ b/lib/spear/acl.ex
@@ -80,7 +80,7 @@ defmodule Spear.Acl do
   @doc """
   Converts an ACL struct to a map with the keys expected by the EventStoreDB
 
-  This function is used internall by `Spear.set_global_acl/4` to create a
+  This function is used internally by `Spear.set_global_acl/4` to create a
   global ACL event body, but may be used to create an acl body on its own.
 
   ## Examples

--- a/lib/spear/connection/request.ex
+++ b/lib/spear/connection/request.ex
@@ -84,7 +84,7 @@ defmodule Spear.Connection.Request do
 
     {:cont, {[], 0, smallest_window}}
     |> continuation.()
-    |> handle_contination(state, request)
+    |> handle_continuation(state, request)
   end
 
   def emit_messages(
@@ -110,11 +110,11 @@ defmodule Spear.Connection.Request do
 
         {:cont, {[{buffer, buffer_size}], buffer_size, smallest_window}}
         |> continuation.()
-        |> handle_contination(state, request)
+        |> handle_continuation(state, request)
     end
   end
 
-  defp handle_contination(
+  defp handle_continuation(
          {finished, {message_buffer, _buffer_size, _max_size}},
          state,
          request
@@ -138,7 +138,7 @@ defmodule Spear.Connection.Request do
     |> post_stream_hook(request.request_ref)
   end
 
-  defp handle_contination(
+  defp handle_continuation(
          {:suspended,
           {[{overload_message, overload_message_size} | messages_that_fit], buffer_size,
            max_size}, next_continuation},

--- a/lib/spear/persistent_subscription/settings.ex
+++ b/lib/spear/persistent_subscription/settings.ex
@@ -60,7 +60,7 @@ defmodule Spear.PersistentSubscription.Settings do
   import Spear.Records.Persistent
 
   @doc false
-  def to_record(settings, opration)
+  def to_record(settings, operation)
 
   def to_record(%__MODULE__{} = settings, :create) do
     create_req_settings(

--- a/lib/spear/request.ex
+++ b/lib/spear/request.ex
@@ -58,7 +58,7 @@ defmodule Spear.Request do
       {"te", "trailers"},
       # {"grpc-timeout", "10S"},
       {"content-type", "application/grpc+proto"},
-      {"grpc-endcoding", "identity"},
+      {"grpc-encoding", "identity"},
       {"grpc-accept-encoding", "identity,deflate,gzip"},
       {"accept-encoding", "identity"},
       {"user-agent", Grpc.user_agent()}

--- a/lib/spear/rpc.ex
+++ b/lib/spear/rpc.ex
@@ -2,7 +2,7 @@ defmodule Spear.Rpc do
   @moduledoc false
   require Record
 
-  # simple struct for an RPC definiton, used by Spear.Service
+  # simple struct for an RPC definition, used by Spear.Service
 
   @type t :: %__MODULE__{}
 

--- a/test/fixtures/version_helper.ex
+++ b/test/fixtures/version_helper.ex
@@ -1,6 +1,6 @@
 defmodule VersionHelper do
   @moduledoc """
-  Provides a function that tags tests depending on their compatibilty with the
+  Provides a function that tags tests depending on their compatibility with the
   EventStoreDB version declared in the env
   """
 

--- a/test/spear/connection/configuration_test.exs
+++ b/test/spear/connection/configuration_test.exs
@@ -96,7 +96,7 @@ defmodule Spear.Connection.ConfigurationTest do
     assert config.valid? == true
   end
 
-  test "mint protocols and mode options cannot be overriden" do
+  test "mint protocols and mode options cannot be overridden" do
     config =
       Config.new(
         scheme: :http,

--- a/test/spear/connection/keep_alive_timer_test.exs
+++ b/test/spear/connection/keep_alive_timer_test.exs
@@ -14,7 +14,7 @@ defmodule Spear.Connection.KeepAliveTimerTest do
     assert timer.timeout_timers == %{}
   end
 
-  test "starting a timeout timer inserts the timer into timout_timers" do
+  test "starting a timeout timer inserts the timer into timeout_timers" do
     ref = make_ref()
 
     timer = %KeepAliveTimer{interval: 20, timeout: 10} |> KeepAliveTimer.start_timeout_timer(ref)
@@ -24,7 +24,7 @@ defmodule Spear.Connection.KeepAliveTimerTest do
     assert Map.has_key?(timer.timeout_timers, ref)
   end
 
-  test "canceling a timeout timer takes the timer out of timout_timers" do
+  test "canceling a timeout timer takes the timer out of timeout_timers" do
     ref = make_ref()
 
     timer =


### PR DESCRIPTION
Found via `codespell -S deps -L ro,te` and `typos --format brief`