### PR TITLE
Fixes typespecs for Spear.read_stream/3

### DIFF
--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -306,7 +306,7 @@ defmodule Spear do
   """
   @doc since: "0.1.0"
   @doc api: :streams
-  @spec read_stream(Spear.Connection.t(), String.t(), Keyword.t()) ::
+  @spec read_stream(Spear.Connection.t(), String.t() | :all, Keyword.t()) ::
           {:ok, event_stream :: Enumerable.t()} | {:error, any()}
   def read_stream(connection, stream_name, opts \\ []) do
     default_read_opts = [


### PR DESCRIPTION
Minor typespec correction, allowing to pass the `:all` atom to `Spear.read_stream/3`.
The functionnality is already supported, this just fixes the spec.