### PR TITLE
fix: configuring the start_link opts without global config

### DIFF
--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -933,7 +933,7 @@ defmodule Spear.Client do
       {:ok, otp_app} ->
         quote do
           def start_link(args) do
-            Application.get_env(unquote(otp_app), __MODULE__)
+            Application.get_env(unquote(otp_app), __MODULE__, [])
             |> Keyword.merge(args)
             |> Keyword.put(:name, __MODULE__)
             |> Spear.Connection.start_link()


### PR DESCRIPTION
I tried the following:

```elixir
defmodule Umbrella.Application do
  use Application

  @impl true
  def start(_type, _args) do
    children = [
      {Umbrella.EventStore.Client, connection_string: "esdb://localhost:2113?tls=true&tlsVerifyCert=false"}
    ]

    Supervisor.start_link(children, strategy: :one_for_one, name: Umbrella.Supervisor)
  end
end

```

**WITHOUT** configuring anything under `config/*` configuration files, thus, it failed because:

```
** (Mix) Could not start application umbrella: Umbrella.Application.start(:normal, []) returned an error: shutdown: failed to start child: Umbrella.EventStore.Client
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in Keyword.merge/2
            (elixir 1.14.5) lib/keyword.ex:979: Keyword.merge(nil, [connection_string: "esdb://localhost:2113?tls=true&tlsVerifyCert=false"])
            (umbrella 0.1.0) lib/umbrella/event_store/client.ex:2: Umbrella.EventStore.Client.start_link/1
            (stdlib 5.0) supervisor.erl:420: :supervisor.do_start_child_i/3
            (stdlib 5.0) supervisor.erl:406: :supervisor.do_start_child/2
            (stdlib 5.0) supervisor.erl:390: anonymous fn/3 in :supervisor.start_children/2
            (stdlib 5.0) supervisor.erl:1256: :supervisor.children_map/4
            (stdlib 5.0) supervisor.erl:350: :supervisor.init_children/2
            (stdlib 5.0) gen_server.erl:962: :gen_server.init_it/2
```