### PR TITLE
fix: `Spear.append/3` `raw?: true` raw return

### DIFF
--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -415,15 +415,11 @@ defmodule Spear do
            messages,
            Keyword.take(opts, [:credentials, :timeout])
          ) do
-      {:ok, Streams.append_resp(result: {:success, _}) = response} when raw? == true ->
+      {:ok, response} when raw? == true ->
         {:ok, response}
 
       {:ok, Streams.append_resp(result: {:success, _})} ->
         :ok
-
-      {:ok, Streams.append_resp(result: {:wrong_expected_version, _}) = response}
-      when raw? == true ->
-        {:error, response}
 
       {:ok, Streams.append_resp(result: {:wrong_expected_version, expectation_violation})} ->
         {:error, Spear.Writing.map_expectation_violation(expectation_violation)}

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -415,7 +415,7 @@ defmodule Spear do
            messages,
            Keyword.take(opts, [:credentials, :timeout])
          ) do
-      {:ok, Streams.append_resp(result: {:success, _} = response)} when raw? == true ->
+      {:ok, Streams.append_resp(result: {:success, _})} = response when raw? == true ->
         {:ok, response}
 
       {:ok, Streams.append_resp(result: {:success, _})} ->

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -415,11 +415,15 @@ defmodule Spear do
            messages,
            Keyword.take(opts, [:credentials, :timeout])
          ) do
-      {:ok, Streams.append_resp(result: {:success, _})} = response when raw? == true ->
+      {:ok, Streams.append_resp(result: {:success, _}) = response} when raw? == true ->
         {:ok, response}
 
       {:ok, Streams.append_resp(result: {:success, _})} ->
         :ok
+
+      {:ok, Streams.append_resp(result: {:wrong_expected_version, _}) = response}
+      when raw? == true ->
+        {:error, response}
 
       {:ok, Streams.append_resp(result: {:wrong_expected_version, expectation_violation})} ->
         {:error, Spear.Writing.map_expectation_violation(expectation_violation)}

--- a/lib/spear.ex
+++ b/lib/spear.ex
@@ -390,7 +390,8 @@ defmodule Spear do
           connection :: Spear.Connection.t(),
           stream_name :: String.t(),
           opts :: Keyword.t()
-        ) :: :ok | {:error, reason :: Spear.ExpectationViolation.t() | any()}
+        ) ::
+          :ok | {:ok, AppendResp.t()} | {:error, reason :: Spear.ExpectationViolation.t() | any()}
   def append(event_stream, conn, stream_name, opts \\ []) when is_binary(stream_name) do
     default_write_opts = [
       expect: :any,
@@ -400,6 +401,7 @@ defmodule Spear do
 
     opts = default_write_opts |> Keyword.merge(opts)
     params = Enum.into(opts, %{})
+    raw? = Keyword.get(opts, :raw?, false)
 
     messages =
       [Spear.Writing.build_append_request(params)]
@@ -413,6 +415,9 @@ defmodule Spear do
            messages,
            Keyword.take(opts, [:credentials, :timeout])
          ) do
+      {:ok, Streams.append_resp(result: {:success, _} = response)} when raw? == true ->
+        {:ok, response}
+
       {:ok, Streams.append_resp(result: {:success, _})} ->
         :ok
 

--- a/lib/spear/client.ex
+++ b/lib/spear/client.ex
@@ -67,14 +67,14 @@ defmodule Spear.Client do
   """
   @doc since: "0.1.0"
   @callback append(event_stream :: Enumerable.t(), stream_name :: String.t()) ::
-              :ok | {:error, any()}
+              :ok | {:ok, AppendResp.t()} | {:error, any()}
 
   @doc """
   A wrapper around `Spear.append/4`
   """
   @doc since: "0.1.0"
   @callback append(event_stream :: Enumerable.t(), stream_name :: String.t(), opts :: Keyword.t()) ::
-              :ok | {:error, any()}
+              :ok | {:ok, AppendResp.t()} | {:error, any()}
 
   @doc """
   A wrapper around `Spear.append_batch/4`

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -1034,8 +1034,7 @@ defmodule SpearTest do
 
       assert {:success,
               {:"event_store.client.streams.BatchAppendResp.Success", {:current_revision, 4},
-               {:position, {:"event_store.client.AllStreamPosition", _p1, _p2}}}} =
-               result
+               {:position, {:"event_store.client.AllStreamPosition", _p1, _p2}}}} = result
 
       assert Spear.cancel_subscription(c.conn, request_id) == :ok
 

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -1040,9 +1040,7 @@ defmodule SpearTest do
         revision: 4
       }
 
-      assert {:success,
-              {:"event_store.client.streams.BatchAppendResp.Success", {:current_revision, 4},
-               {:position, {:"event_store.client.AllStreamPosition", _p1, _p2}}}} = result
+      assert {:success, Streams.batch_append_resp_success()} = result
 
       assert Spear.cancel_subscription(c.conn, request_id) == :ok
 

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -936,9 +936,11 @@ defmodule SpearTest do
                |> Stream.take(7)
                |> Spear.append(c.conn, c.stream_name, expect: :empty, raw?: true)
 
-      assert {:success,
-              {:"event_store.client.streams.AppendResp.Success", {:current_revision, 6},
-               {:position, {:"event_store.client.streams.AppendResp.Position", _p1, _p2}}}} =
+      assert {:ok,
+              {:"event_store.client.streams.AppendResp",
+               {:success,
+                {:"event_store.client.streams.AppendResp.Success", {:current_revision, 6},
+                 {:position, {:"event_store.client.streams.AppendResp.Position", _p1, _p2}}}}}} =
                result
     end
 

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -997,6 +997,7 @@ defmodule SpearTest do
       assert Spear.stream!(c.conn, c.stream_name) |> Enum.map(& &1.body) == Enum.to_list(0..19)
     end
 
+    @tag compatible(">= 21.6.0")
     test "the append_batch/5 with `raw?: false` returns :ok", c do
       assert {:ok, batch_id, request_id} =
                random_events()
@@ -1017,6 +1018,7 @@ defmodule SpearTest do
       assert Spear.stream!(c.conn, c.stream_name) |> Enum.map(& &1.body) == Enum.to_list(0..4)
     end
 
+    @tag compatible(">= 21.6.0")
     test "the append_batch/5 with `raw?: true` returns the raw result", c do
       assert {:ok, batch_id, request_id} =
                random_events()

--- a/test/spear_test.exs
+++ b/test/spear_test.exs
@@ -931,17 +931,26 @@ defmodule SpearTest do
     end
 
     test "the append/3 with `raw?: true` returns the raw result", c do
-      assert {:ok, result} =
+      assert {:ok, response} =
                random_events()
                |> Stream.take(7)
                |> Spear.append(c.conn, c.stream_name, expect: :empty, raw?: true)
 
-      assert {:ok,
-              {:"event_store.client.streams.AppendResp",
-               {:success,
-                {:"event_store.client.streams.AppendResp.Success", {:current_revision, 6},
-                 {:position, {:"event_store.client.streams.AppendResp.Position", _p1, _p2}}}}}} =
-               result
+      assert {:"event_store.client.streams.AppendResp",
+              {:success,
+               {:"event_store.client.streams.AppendResp.Success", {:current_revision, 6},
+                {:position, {:"event_store.client.streams.AppendResp.Position", _p1, _p2}}}}} =
+               response
+    end
+
+    test "the append/3 with `raw?: true` returns expectation error as raw", c do
+      assert {:error, response} =
+               random_events()
+               |> Stream.take(1)
+               |> Spear.append(c.conn, c.stream_name, expect: 9999, raw?: true)
+
+      assert {:"event_store.client.streams.AppendResp",
+              {:wrong_expected_version, _wrong_expected_version_pb_tuple}} = response
     end
 
     @tag compatible(">= 21.6.0")


### PR DESCRIPTION
# Context

Issue #96

Passing a `raw?: true` option to `Spear.append/3` or `Spear.Client/append` continued to return `:ok` instead of `{:ok, AppendResp.t()}`.

This contradicted the docs and the `Spear.append_batch/5` behaviour.

# Solution

This commit adds the conditional case in `Spear.append/3` to return `{:ok, AppendResp.t()}` when `raw?` is `true`.

`Spear.Client.append` will also be fixed as a result.

# Additional Notes

* Added to `SpearTest`: to test `append/3` for both raw true and false
* Added to `SpearTest`: to test `append_batch/5` for both raw true and false.
* Updated the `Spear.append/3` type spec to add the missing `{:ok, AppendResp.t()}` return type.
* Updated the `Spear.Client.append/3` and `Spear.Client.append/4` callback specs to add the missing `{:ok, AppendResp.t()}` return type.