### PR TITLE
fix(connection): enable TCP nodelay by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ behind new EventStoreDB versions. You should not downgrade your Spear version
 in order to avoid these features: Spear aims to keep a stable interface usable
 across all EventStoreDB versions v20+.
 
+## Unreleased
+
+### Fixed
+
+- Enabled `nodelay: true` on the TCP transport by default to disable Nagle's
+  algorithm, reducing latency for the small request/response messages exchanged
+  with the EventStoreDB.
+    - This default can be overridden via `mint_opts: [transport_opts: [nodelay: false]]`.
+
 ## 1.4.1 - 2024-08-03
 
 ### Fixed

--- a/lib/spear/connection/configuration.ex
+++ b/lib/spear/connection/configuration.ex
@@ -1,5 +1,6 @@
 defmodule Spear.Connection.Configuration do
   @default_mint_opts [protocols: [:http2], mode: :active]
+  @default_transport_opts [nodelay: true]
   @moduledoc """
   Configuration for `Spear.Connection`s
 
@@ -20,6 +21,10 @@ defmodule Spear.Connection.Configuration do
     list of options to pass to mint. The default values cannot be overridden.
     This can be useful for configuring TLS. See the
     [security guide](guides/security.md) for more information.
+    `#{inspect(@default_transport_opts)}` is merged into the `:transport_opts`
+    to disable Nagle's algorithm, which reduces latency for the small
+    request/response messages exchanged with the EventStoreDB. This default
+    can be overridden by providing `:nodelay` in `:transport_opts`.
 
   * `:host` - (default: `"localhost"`) the host address of the EventStoreDB
 
@@ -194,10 +199,15 @@ defmodule Spear.Connection.Configuration do
   end
 
   defp override_mint_opts(opts) do
+    user_mint_opts = Keyword.get(opts, :mint_opts, [])
+
+    transport_opts =
+      Keyword.merge(@default_transport_opts, Keyword.get(user_mint_opts, :transport_opts, []))
+
     mint_opts =
-      opts
-      |> Keyword.get(:mint_opts, [])
+      user_mint_opts
       |> Keyword.merge(@default_mint_opts)
+      |> Keyword.put(:transport_opts, transport_opts)
 
     Keyword.merge(opts, mint_opts: mint_opts)
   end

--- a/test/spear/connection/configuration_test.exs
+++ b/test/spear/connection/configuration_test.exs
@@ -111,4 +111,26 @@ defmodule Spear.Connection.ConfigurationTest do
     assert config.mint_opts[:protocols] == [:http2]
     assert config.mint_opts[:mode] == :active
   end
+
+  test "nodelay is enabled by default on the transport" do
+    config =
+      Config.new(
+        host: "localhost",
+        port: 2113
+      )
+
+    assert config.mint_opts[:transport_opts][:nodelay] == true
+  end
+
+  test "nodelay default can be overridden and merges with user transport_opts" do
+    config =
+      Config.new(
+        host: "localhost",
+        port: 2113,
+        mint_opts: [transport_opts: [nodelay: false, cacertfile: "/path/to/ca"]]
+      )
+
+    assert config.mint_opts[:transport_opts][:nodelay] == false
+    assert config.mint_opts[:transport_opts][:cacertfile] == "/path/to/ca"
+  end
 end


### PR DESCRIPTION
- Small gRPC request/response messages were subject to Nagle's algorithm interacting with delayed ACKs, adding tens of milliseconds of latency to otherwise fast reads and appends. Enabling `nodelay` by default removes that latency for the common workload without requiring callers to hand-tune `mint_opts`.
- The same root cause and fix were confirmed upstream in the KurrentDB Rust client, which now sets `TCP_NODELAY` by default: kurrent-io/KurrentDB-Client-Rust#233 (closing kurrent-io/KurrentDB-Client-Rust#232).

Closes #92
